### PR TITLE
Support for operations at response level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Unreleased
 
-* rename `BearerToken#expires_in` to `expires_at` (#16)
-* rename argument `allow_guest:` for `API::Endpoint#connection` to `fallback_to_guest:` (#16)
+* Rename `BearerToken#expires_in` to `expires_at` (#16)
+* Rename argument `allow_guest:` for `API::Endpoint#connection` to `fallback_to_guest:` (#16)
+* Response objects can access the operation directly using `.operation` (#15)
 * New API: billing api (#14)
   * New endpoint: `profile`. Methods: `show`, `create`, `update`
 

--- a/lib/scalingo/api/endpoint.rb
+++ b/lib/scalingo/api/endpoint.rb
@@ -16,7 +16,7 @@ module Scalingo
       private
 
       def unpack(*args)
-        Response.unpack(*args)
+        Response.unpack(client, *args)
       end
     end
   end

--- a/lib/scalingo/regional/operations.rb
+++ b/lib/scalingo/regional/operations.rb
@@ -3,10 +3,18 @@ require "scalingo/api/endpoint"
 module Scalingo
   class Regional::Operations < API::Endpoint
     def find(app_id, operation_id, headers = nil, &block)
+      get(
+        "apps/#{app_id}/operations/#{operation_id}",
+        headers,
+        &block
+      )
+    end
+
+    def get(url, headers = nil, &block)
       data = nil
 
       response = connection.get(
-        "apps/#{app_id}/operations/#{operation_id}",
+        url,
         data,
         headers,
         &block

--- a/spec/scalingo/api/endpoint_spec.rb
+++ b/spec/scalingo/api/endpoint_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Scalingo::API::Endpoint do
 
   describe "unpack" do
     it "forwards unpack to Response" do
-      expect(Scalingo::API::Response).to receive(:unpack).with(:a, :b, :c).and_return(:d).once
+      expect(Scalingo::API::Response).to receive(:unpack).with(client, :a, :b, :c).and_return(:d).once
 
       expect(subject.send(:unpack, :a, :b, :c)).to eq :d
     end

--- a/spec/scalingo/api/response_spec.rb
+++ b/spec/scalingo/api/response_spec.rb
@@ -1,0 +1,270 @@
+require "spec_helper"
+
+RSpec.describe Scalingo::API::Response do
+  let(:client) { regional }
+  let(:status) { 200 }
+  let(:headers) { {} }
+  let(:data) { "" }
+  let(:full_body) { "" }
+  let(:meta_object) { nil }
+
+  subject {
+    described_class.new(
+      client: client,
+      status: status,
+      headers: headers,
+      data: data,
+      full_body: full_body,
+      meta: meta_object,
+    )
+  }
+
+  describe "self.unpack" do
+    let(:body) { "" }
+
+    let(:response) {
+      OpenStruct.new(
+        body: body,
+        status: status,
+        headers: headers,
+      )
+    }
+
+    it "passes the client supplied" do
+      object = described_class.unpack(:some_client, response)
+
+      expect(object.client).to eq :some_client
+    end
+
+    it "passes the response status" do
+      object = described_class.unpack(:client, response)
+
+      expect(object.status).to eq status
+    end
+
+    it "passes the response headers" do
+      object = described_class.unpack(:client, response)
+
+      expect(object.headers).to eq headers
+    end
+
+    context "with an empty body" do
+      let(:body) { "" }
+
+      it "without key" do
+        object = described_class.unpack(client, response)
+
+        expect(object.data).to eq ""
+        expect(object.full_body).to eq ""
+        expect(object.meta).to eq nil
+      end
+
+      it "ignores key if supplied" do
+        object = described_class.unpack(client, response, key: :key)
+
+        expect(object.data).to eq ""
+        expect(object.full_body).to eq ""
+        expect(object.meta).to eq nil
+      end
+    end
+
+    context "with a nil body" do
+      let(:body) { nil }
+
+      it "without key" do
+        object = described_class.unpack(client, response)
+
+        expect(object.data).to eq nil
+        expect(object.full_body).to eq nil
+        expect(object.meta).to eq nil
+      end
+
+      it "ignores key if supplied" do
+        object = described_class.unpack(client, response, key: :key)
+
+        expect(object.data).to eq nil
+        expect(object.full_body).to eq nil
+        expect(object.meta).to eq nil
+      end
+    end
+
+    context "with a string body" do
+      let(:body) { "this is a string body, probably due to an error" }
+
+      it "without key" do
+        object = described_class.unpack(client, response)
+
+        expect(object.data).to eq body
+        expect(object.full_body).to eq body
+        expect(object.meta).to eq nil
+      end
+
+      it "ignores key if supplied" do
+        object = described_class.unpack(client, response, key: :key)
+
+        expect(object.data).to eq body
+        expect(object.full_body).to eq body
+        expect(object.meta).to eq nil
+      end
+    end
+
+    context "with an json (array) body" do
+      let(:body) {
+        [{key: :value}]
+      }
+
+      it "without key" do
+        object = described_class.unpack(client, response)
+
+        expect(object.data).to eq body
+        expect(object.full_body).to eq body
+        expect(object.meta).to eq nil
+      end
+
+      it "ignores key if supplied" do
+        object = described_class.unpack(client, response, key: :root)
+
+        expect(object.data).to eq body
+        expect(object.full_body).to eq body
+        expect(object.meta).to eq nil
+      end
+    end
+
+    context "with a json (hash) body" do
+      let(:body) {
+        {root: {key: :value}}
+      }
+
+      it "without key" do
+        object = described_class.unpack(client, response)
+
+        expect(object.data).to eq body
+        expect(object.full_body).to eq body
+        expect(object.meta).to eq nil
+      end
+
+      it "with valid key" do
+        object = described_class.unpack(client, response, key: :root)
+
+        expect(object.data).to eq({key: :value})
+        expect(object.full_body).to eq body
+        expect(object.meta).to eq nil
+      end
+
+      it "with invalid key" do
+        object = described_class.unpack(client, response, key: :other)
+
+        expect(object.data).to eq nil
+        expect(object.full_body).to eq body
+        expect(object.meta).to eq nil
+      end
+
+      context "with meta" do
+        let(:body) {
+          {root: {key: :value}, meta: {meta1: :value}}
+        }
+
+        it "extracts the meta object" do
+          object = described_class.unpack(client, response)
+
+          expect(object.meta).to eq({meta1: :value})
+        end
+      end
+    end
+  end
+
+  describe "successful?" do
+    context "is true when 2XX" do
+      let(:status) { 200 }
+      it { expect(subject.successful?).to be true }
+    end
+
+    context "is false when 3XX" do
+      let(:status) { 300 }
+      it { expect(subject.successful?).to be false }
+    end
+
+    context "is false when 4XX" do
+      let(:status) { 400 }
+      it { expect(subject.successful?).to be false }
+    end
+
+    context "is false when 5XX" do
+      let(:status) { 500 }
+      it { expect(subject.successful?).to be false }
+    end
+  end
+
+  describe "paginated?" do
+    context "with pagination metadata" do
+      let(:meta_object) {
+        {pagination: {page: 1}}
+      }
+
+      it { expect(subject.paginated?).to be true }
+    end
+
+    context "without pagination metadata" do
+      let(:meta_object) {
+        {messages: []}
+      }
+
+      it { expect(subject.paginated?).to be false }
+    end
+  end
+
+  describe "operation" do
+    context "with an operation url" do
+      before do
+        load_meta!(api: :regional, folder: :operations)
+        register_stubs!("find-200", api: :regional, folder: :operations)
+      end
+
+      let(:url) {
+        path = "/apps/#{meta[:app_id]}/operations/#{meta[:id]}"
+        File.join(Scalingo::ENDPOINTS[:regional], path)
+      }
+
+      let(:headers) {
+        {location: url}
+      }
+
+      it { expect(subject.operation?).to be true }
+      it { expect(subject.operation_url).to eq url }
+
+      it "can request the operation" do
+        response = subject.operation
+
+        expect(response).to be_successful
+        expect(response.data[:id]).to be_present
+        expect(response.data[:status]).to be_present
+        expect(response.data[:type]).to be_present
+      end
+
+      it "delegates the operation to the given client" do
+        mock = double
+
+        expect(subject.client).to receive(:operations).and_return(mock)
+        expect(mock).to receive(:get).with(url).and_return(:response)
+
+        expect(subject.operation).to eq :response
+      end
+
+      context "when the client doesn't know about operations" do
+        let(:client) { auth }
+
+        it "fails silently" do
+          expect(subject.operation).to eq nil
+        end
+      end
+    end
+
+    context "without an operation url" do
+      let(:meta_object) { {} }
+
+      it { expect(subject.operation?).to be false }
+      it { expect(subject.operation_url).to eq nil }
+      it { expect(subject.operation).to eq nil }
+    end
+  end
+end

--- a/spec/scalingo/regional/operations_spec.rb
+++ b/spec/scalingo/regional/operations_spec.rb
@@ -1,19 +1,27 @@
 require "spec_helper"
 
 RSpec.describe Scalingo::Regional::Operations do
-  describe_method "find" do
+  describe_method "get" do
     context "success" do
-      let(:arguments) { [meta[:app_id], meta[:id]] }
+      let(:arguments) { "apps/#{meta[:app_id]}/operations/#{meta[:id]}" }
       let(:stub_pattern) { "find-200" }
 
       it_behaves_like "a singular object response"
     end
 
     context "failure" do
-      let(:arguments) { [meta[:app_id], meta[:not_found_id]] }
+      let(:arguments) { "apps/#{meta[:app_id]}/operations/#{meta[:not_found_id]}" }
       let(:stub_pattern) { "find-404" }
 
       it_behaves_like "a not found response"
+    end
+  end
+
+  describe_method "find" do
+    it "delegates to get" do
+      expect(subject).to receive(:get).with("apps/a/operations/b", :headers).once
+
+      subject.find(:a, :b, :headers)
     end
   end
 end

--- a/spec/support/scalingo.rb
+++ b/spec/support/scalingo.rb
@@ -17,8 +17,11 @@ module Scalingo
       File.join(project_root, "samples")
     end
 
-    def load_meta!
-      api, folder = described_class.to_s.underscore.split("/").last(2)
+    def load_meta!(api: nil, folder: nil)
+      guessed_api, guessed_folder = described_class.to_s.underscore.split("/").last(2)
+      api ||= guessed_api
+      folder ||= guessed_folder
+
       path = [samples_root, api, folder, "_meta.json"].compact.join("/")
 
       if File.exist?(path)
@@ -26,8 +29,11 @@ module Scalingo
       end
     end
 
-    def register_stubs!(pattern = "**/*")
-      api, folder = described_class.to_s.underscore.split("/").last(2)
+    def register_stubs!(pattern = "**/*", api: nil, folder: nil)
+      guessed_api, guessed_folder = described_class.to_s.underscore.split("/").last(2)
+      api ||= guessed_api
+      folder ||= guessed_folder
+
       endpoint = ENDPOINTS.fetch(api.to_sym)
 
       path = [samples_root, api, folder].compact.join("/")


### PR DESCRIPTION
This PR

* allows to query an operation directly from its path with `get`; `find` still accepts `app_id` and `id` and will leverage `get`;
* adds an `operation` method to the responses objects

All of this makes the following valid : 

```ruby
restart_response = scalingo.region.containers.restart("my-app-name")
operation_response = restart_response.operation
operation_response.data[:status]
```

This also adds spec coverage for Response objects, and removes dead code related to response parsing/object transformation.