### PR TITLE
Missing configuration, missing specs, missing endpoint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,14 @@ Style/TrailingCommaInArguments:
   Enabled: true
   EnforcedStyleForMultiline: consistent_comma
 
+Style/TrailingCommaInArrayLiteral:
+  Enabled: true
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: true
+  EnforcedStyleForMultiline: consistent_comma
+
 Style/Alias:
   Enabled: true
   EnforcedStyle: prefer_alias_method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Bugfix: remove `https` configuration option (development artifact) (#20)
 * Improv: configure the faraday adapter to use (#20)
+* Improv: prettier `inspect` for common objects (#20)
 
 ## 3.0.0.beta.2 - 2020/06/18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Bugfix: remove `https` configuration option (development artifact) (#20)
 * Improv: configure the faraday adapter to use (#20)
 * Improv: prettier `inspect` for common objects (#20)
+* New: Add `addons#token` endpoint (#20)
 
 ## 3.0.0.beta.2 - 2020/06/18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+* Bugfix: remove `https` configuration option (development artifact) (#20)
+* Improv: configure the faraday adapter to use (#20)
+
 ## 3.0.0.beta.2 - 2020/06/18
 
 * Bugfix: do not "dig" into the response body if it is not a 2XX (#18, #19)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ Scalingo.configure do |config|
   # These headers will be added to every request. Individual methods may override them.
   # This should be a hash or a callable object that returns a hash.
   config.additional_headers = {}
+
+  # Specify an adapter for faraday. Leave nil for the default one (Net::HTTP)
+  config.faraday_adapter = nil
 end
 ```
 

--- a/lib/scalingo/api/client.rb
+++ b/lib/scalingo/api/client.rb
@@ -66,6 +66,8 @@ module Scalingo
         @unauthenticated_conn ||= Faraday.new(connection_options) { |conn|
           conn.response :json, content_type: /\bjson$/, parser_options: {symbolize_names: true}
           conn.request :json
+
+          conn.adapter(scalingo.config.faraday_adapter) if scalingo.config.faraday_adapter
         }
       end
 
@@ -89,6 +91,8 @@ module Scalingo
             auth_header = Faraday::Request::Authorization.header "Bearer", scalingo.token.value
             conn.headers[Faraday::Request::Authorization::KEY] = auth_header
           end
+
+          conn.adapter(scalingo.config.faraday_adapter) if scalingo.config.faraday_adapter
         }
       end
     end

--- a/lib/scalingo/api/client.rb
+++ b/lib/scalingo/api/client.rb
@@ -27,6 +27,16 @@ module Scalingo
         end
       end
 
+      def inspect
+        str = %(<#{self.class}:0x#{object_id.to_s(16)} scalingo:#{@scalingo.inspect} url:"#{@url}" methods:)
+
+        methods = self.class.instance_methods - Scalingo::API::Client.instance_methods
+        str << methods.to_s
+
+        str << ">"
+        str
+      end
+
       ## Faraday objects
       def headers
         hash = {

--- a/lib/scalingo/api/client.rb
+++ b/lib/scalingo/api/client.rb
@@ -30,7 +30,7 @@ module Scalingo
       ## Faraday objects
       def headers
         hash = {
-          "User-Agent" => scalingo.config.user_agent
+          "User-Agent" => scalingo.config.user_agent,
         }
 
         if (extra = scalingo.config.additional_headers).present?
@@ -43,7 +43,7 @@ module Scalingo
       def connection_options
         {
           url: url,
-          headers: headers
+          headers: headers,
         }
       end
 

--- a/lib/scalingo/api/endpoint.rb
+++ b/lib/scalingo/api/endpoint.rb
@@ -13,6 +13,16 @@ module Scalingo
 
       def_delegator :client, :connection
 
+      def inspect
+        str = %(<#{self.class}:0x#{object_id.to_s(16)} base_url:"#{@client.url}" endpoints:)
+
+        methods = self.class.instance_methods - Scalingo::API::Endpoint.instance_methods
+
+        str << methods.to_s
+        str << ">"
+        str
+      end
+
       private
 
       def unpack(*args)

--- a/lib/scalingo/api/response.rb
+++ b/lib/scalingo/api/response.rb
@@ -34,6 +34,10 @@ module Scalingo
         @meta = meta
       end
 
+      def inspect
+        %(<#{self.class}:0x#{object_id.to_s(16)} status:#{@status} data:#{@data} meta:#{@meta}>)
+      end
+
       def successful?
         status >= 200 && status < 300
       end

--- a/lib/scalingo/auth/tokens.rb
+++ b/lib/scalingo/auth/tokens.rb
@@ -8,7 +8,7 @@ module Scalingo
       authorization = Faraday::Request::BasicAuthentication.header("", token)
 
       request_headers = {
-        Faraday::Request::Authorization::KEY => authorization
+        Faraday::Request::Authorization::KEY => authorization,
       }
 
       request_headers.update(headers) if headers

--- a/lib/scalingo/bearer_token.rb
+++ b/lib/scalingo/bearer_token.rb
@@ -9,6 +9,21 @@ module Scalingo
       @raise_on_expired = raise_on_expired
     end
 
+    def inspect
+      str = "<#{self.class}:0x#{object_id.to_s(16)} "
+
+      str << if expired?
+        "(expired) "
+      elsif expires_at.present?
+        "expires_at: #{expires_at} "
+      else
+        "(no expiration) "
+      end
+
+      str << %(value:"#{value}">)
+      str
+    end
+
     def raise_on_expired?
       @raise_on_expired
     end

--- a/lib/scalingo/client.rb
+++ b/lib/scalingo/client.rb
@@ -19,6 +19,19 @@ module Scalingo
       define_regions!
     end
 
+    def inspect
+      str = %(<#{self.class}:0x#{object_id.to_s(16)} version:"#{Scalingo::VERSION}" authenticated:)
+
+      str << if token.present?
+        (token.expired? ? "expired" : "true")
+      else
+        "false"
+      end
+
+      str << ">"
+      str
+    end
+
     ## Authentication helpers / Token management
     attr_reader :token
 

--- a/lib/scalingo/configuration.rb
+++ b/lib/scalingo/configuration.rb
@@ -17,9 +17,6 @@ module Scalingo
       # Default region. Must match a key in `regions`
       :default_region,
 
-      # Wether to use https or http
-      :https,
-
       # Configure the User Agent header
       :user_agent,
 
@@ -36,7 +33,10 @@ module Scalingo
 
       # These headers will be added to every request. Individual methods may override them.
       # This should be a hash or a callable object that returns a hash.
-      :additional_headers
+      :additional_headers,
+
+      # Specify an adapter for faraday. Leave nil for the default one (Net::HTTP)
+      :faraday_adapter,
     ]
 
     ATTRIBUTES.each { |attr| attr_accessor(attr) }

--- a/lib/scalingo/configuration.rb
+++ b/lib/scalingo/configuration.rb
@@ -48,7 +48,7 @@ module Scalingo
         regions: {
           agora_fr1: "https://api.agora-fr1.scalingo.com/v1",
           osc_fr1: "https://api.osc-fr1.scalingo.com/v1",
-          osc_secnum_fr1: "https://api.osc-secnum-fr1.scalingo.com/v1"
+          osc_secnum_fr1: "https://api.osc-secnum-fr1.scalingo.com/v1",
         },
         default_region: :osc_fr1,
         user_agent: "Scalingo Ruby Client v#{Scalingo::VERSION}",

--- a/lib/scalingo/regional/addons.rb
+++ b/lib/scalingo/regional/addons.rb
@@ -80,6 +80,19 @@ module Scalingo
       unpack(response, key: :addon)
     end
 
+    def token(app_id, addon_id, headers = nil, &block)
+      data = nil
+
+      response = connection.post(
+        "apps/#{app_id}/addons/#{addon_id}/token",
+        data,
+        headers,
+        &block
+      )
+
+      unpack(response, key: :addon)
+    end
+
     def categories(headers = nil, &block)
       data = nil
 

--- a/samples/regional/addons/token-200.json
+++ b/samples/regional/addons/token-200.json
@@ -1,0 +1,49 @@
+{
+  "path": "/apps/5ed10967884fef000f5e4fff/addons/ad-6733873b-1628-4b8e-8e74-c30f1c3f3b63/token",
+  "method": "post",
+  "request": {
+    "headers": {
+      "Authorization": "Bearer the-bearer-token"
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Date": "Fri, 29 May 2020 13:09:00 GMT",
+      "Etag": "W/\"ece1ff1263aad47584f356e20127cf3b\"",
+      "Content-Type": "application/json; charset=utf-8",
+      "Transfer-Encoding": "chunked",
+      "Connection": "keep-alive",
+      "Cache-Control": "max-age=0, private, must-revalidate",
+      "Referrer-Policy": "strict-origin-when-cross-origin"
+    },
+    "json_body": {
+      "addon": {
+        "id": "ad-6733873b-1628-4b8e-8e74-c30f1c3f3b63",
+        "app_id": "5ed10967884fef000f5e4fff",
+        "resource_id": "some_example_5629",
+        "addon_provider": {
+          "id": "postgresql",
+          "name": "PostgreSQL",
+          "logo_url": "//cdn.scalingo.com/addons/Scalingo_Postgresql.svg"
+        },
+        "plan": {
+          "id": "5d1e03873e6b3b000eefa827",
+          "name": "postgresql-sandbox",
+          "display_name": "Sandbox",
+          "price": 0.0,
+          "description": "<p>Pouet</p>\n",
+          "position": null,
+          "on_demand": false,
+          "disabled": false,
+          "disabled_alternative_plan_id": null,
+          "sku": "ovh-st-fr1-postgresql-sandbox"
+        },
+        "provisioned_at": "2020-05-29T13:08:58.103Z",
+        "deprovisioned_at": null,
+        "status": "provisioning",
+        "token": "eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJTY2FsaW5nbyIsImlhdCI6MTU5Mjg0MjQ3OSwidXVpZCI6InVzLTY3NmJiMGMxLTFjYTktNDY4Mi04ZWUxLTI1NzQyMmU5ZWFiNSIsInJuZCI6IjlhZGZlMzNlNDUxNzNmZTBiNjg4ZjQxZTY4OTg1OWQ0IiwiZXhwIjoxNTkyODQ2MDc5LCJhZGRvbl91dWlkIjoiYWQtNTRlYzczMzItYjViOS00MGUyLTg2NWQtYmNkYTg1Yzc2Y2I2In0.-rYijDhFRWcycSFLcCbdQD3tg9rh1MhXE_rTvlOtQt-48BJcPmxH9Wpazzp7tkspYrx8jfIrWrALoujvW33WVw"
+      }
+    }
+  }
+}

--- a/samples/regional/addons/token-404.json
+++ b/samples/regional/addons/token-404.json
@@ -1,0 +1,24 @@
+{
+  "path": "/apps/5ed10967884fef000f5e4fff/addons/wrong-addon-id/token",
+  "method": "post",
+  "request": {
+    "headers": {
+      "Authorization": "Bearer the-bearer-token"
+    }
+  },
+  "response": {
+    "status": 404,
+    "headers": {
+      "Date": "Fri, 29 May 2020 13:08:59 GMT",
+      "Content-Type": "application/json; charset=utf-8",
+      "Transfer-Encoding": "chunked",
+      "Connection": "keep-alive",
+      "Cache-Control": "no-cache",
+      "Referrer-Policy": "strict-origin-when-cross-origin"
+    },
+    "json_body": {
+      "resource": "addon",
+      "error": "not found"
+    }
+  }
+}

--- a/scalingo.gemspec
+++ b/scalingo.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     "changelog_uri" => "https://github.com/Scalingo/scalingo-ruby-api/blob/master/CHANGELOG.md",
     "documentation_uri" => "https://developers.scalingo.com/",
     "homepage_uri" => "https://www.scalingo.com/",
-    "source_code_uri" => "https://github.com/Scalingo/scalingo-ruby-api"
+    "source_code_uri" => "https://github.com/Scalingo/scalingo-ruby-api",
   }
 
   # Specify which files should be added to the gem when it is released.

--- a/spec/scalingo/billing_spec.rb
+++ b/spec/scalingo/billing_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+RSpec.describe Scalingo::Billing do
+  subject { described_class.new(:client, "url") }
+
+  %w[profile].each do |section|
+    it "handles requests for #{section}" do
+      expect(subject.respond_to?(section)).to be true
+    end
+  end
+end

--- a/spec/scalingo/configuration_spec.rb
+++ b/spec/scalingo/configuration_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Scalingo::Configuration do
   describe "regions" do
     it "can be assigned from a hash" do
       subject.regions = {
-        local_name: "some-url"
+        local_name: "some-url",
       }
 
       expect(subject.regions.local_name).to eq "some-url"

--- a/spec/scalingo/configuration_spec.rb
+++ b/spec/scalingo/configuration_spec.rb
@@ -52,4 +52,36 @@ RSpec.describe Scalingo::Configuration do
       expect(object.user_agent).to eq "Agent"
     end
   end
+
+  describe "faraday adapter" do
+    let(:scalingo) { Scalingo::Client.new(config).tap { |s| s.authenticate_with(bearer_token: "some-token") } }
+    let(:client) { Scalingo::API::Client.new(scalingo, "http://example.test") }
+
+    context "when unspecified" do
+      let(:config) { {} }
+
+      it "uses the default one when unspecificied" do
+        expect(client.authenticated_connection.adapter).to eq Faraday::Adapter::NetHttp
+        expect(client.unauthenticated_connection.adapter).to eq Faraday::Adapter::NetHttp
+      end
+    end
+
+    context "when set to an unkown adapter" do
+      let(:config) { {faraday_adapter: :yo} }
+
+      it "uses the default one when unspecificied" do
+        expect { client.authenticated_connection.adapter }.to raise_error(Faraday::Error)
+        expect { client.unauthenticated_connection.adapter }.to raise_error(Faraday::Error)
+      end
+    end
+
+    context "when set to a valid adapter" do
+      let(:config) { {faraday_adapter: :test} }
+
+      it "uses the default one when unspecificied" do
+        expect(client.authenticated_connection.adapter).to eq Faraday::Adapter::Test
+        expect(client.unauthenticated_connection.adapter).to eq Faraday::Adapter::Test
+      end
+    end
+  end
 end

--- a/spec/scalingo/regional/addons_spec.rb
+++ b/spec/scalingo/regional/addons_spec.rb
@@ -99,6 +99,22 @@ RSpec.describe Scalingo::Regional::Addons do
     end
   end
 
+  describe_method "token" do
+    context "success" do
+      let(:arguments) { [meta[:app_id], meta[:id]] }
+      let(:stub_pattern) { "token-200" }
+
+      it_behaves_like "a singular object response"
+    end
+
+    context "not found" do
+      let(:arguments) { [meta[:app_id], meta[:not_found_id]] }
+      let(:stub_pattern) { "token-404" }
+
+      it_behaves_like "a not found response"
+    end
+  end
+
   describe_method "update" do
     context "success" do
       let(:arguments) { [meta[:app_id], meta[:id], meta[:update][:valid]] }

--- a/spec/support/scalingo.rb
+++ b/spec/support/scalingo.rb
@@ -5,7 +5,7 @@ module Scalingo
   ENDPOINTS = {
     auth: "https://auth.scalingo.test",
     billing: "https://billing.scalingo.test",
-    regional: "https://regional.scalingo.test"
+    regional: "https://regional.scalingo.test",
   }
 
   module StubHelpers
@@ -64,7 +64,7 @@ module Scalingo
 
         response_options = {
           status: stub_data.dig(:response, :status) || 200,
-          headers: {}
+          headers: {},
         }
 
         if stub_data.dig(:response, :json_body).present?


### PR DESCRIPTION
* Allows configuration of the faraday adapter
* Remove leftover artefact
* Keep trailing commas (linter config)
* Add a missing spec for the billing api client
* Add `token` method