### PR TITLE
Timeout handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Bugfix: remove `https` configuration option (development artifact) (#20)
+* Improv: handle timeouts. Breaks an internal API. (#21, #22)
 * Improv: configure the faraday adapter to use (#20)
 * Improv: prettier `inspect` for common objects (#20)
 * New: Add `addons#token` endpoint (#20)

--- a/lib/scalingo/api/endpoint.rb
+++ b/lib/scalingo/api/endpoint.rb
@@ -25,8 +25,8 @@ module Scalingo
 
       private
 
-      def unpack(*args)
-        Response.unpack(client, *args)
+      def unpack(key = nil, &block)
+        Response.unpack(client, key: key, &block)
       end
     end
   end

--- a/lib/scalingo/api/response.rb
+++ b/lib/scalingo/api/response.rb
@@ -1,7 +1,9 @@
 module Scalingo
   module API
     class Response
-      def self.unpack(client, response, key: nil)
+      def self.unpack(client, key: nil, &block)
+        response = block.call
+
         body = response.body
         has_hash_body = body.present? && body.respond_to?(:key)
 

--- a/lib/scalingo/auth/keys.rb
+++ b/lib/scalingo/auth/keys.rb
@@ -12,7 +12,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :keys)
+      unpack(:keys) { response }
     end
 
     def show(id, headers = nil, &block)
@@ -25,7 +25,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :key)
+      unpack(:key) { response }
     end
 
     def create(payload, headers = nil, &block)
@@ -38,7 +38,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :key)
+      unpack(:key) { response }
     end
 
     def destroy(id, headers = nil, &block)
@@ -50,7 +50,7 @@ module Scalingo
         &block
       )
 
-      unpack(response)
+      unpack { response }
     end
   end
 end

--- a/lib/scalingo/auth/scm_integrations.rb
+++ b/lib/scalingo/auth/scm_integrations.rb
@@ -12,7 +12,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :scm_integrations)
+      unpack(:scm_integrations) { response }
     end
 
     def show(id, headers = nil, &block)
@@ -25,7 +25,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :scm_integration)
+      unpack(:scm_integration) { response }
     end
 
     def create(payload, headers = nil, &block)
@@ -38,7 +38,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :scm_integration)
+      unpack(:scm_integration) { response }
     end
 
     def destroy(id, headers = nil, &block)
@@ -51,7 +51,7 @@ module Scalingo
         &block
       )
 
-      unpack(response)
+      unpack { response }
     end
   end
 end

--- a/lib/scalingo/auth/tokens.rb
+++ b/lib/scalingo/auth/tokens.rb
@@ -20,7 +20,7 @@ module Scalingo
         &block
       )
 
-      unpack(response)
+      unpack { response }
     end
 
     def all(headers = nil, &block)
@@ -33,7 +33,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :tokens)
+      unpack(:tokens) { response }
     end
 
     def create(payload, headers = nil, &block)
@@ -46,7 +46,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :token)
+      unpack(:token) { response }
     end
 
     def renew(id, headers = nil, &block)
@@ -59,7 +59,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :token)
+      unpack(:token) { response }
     end
 
     def destroy(id, headers = nil, &block)
@@ -72,7 +72,7 @@ module Scalingo
         &block
       )
 
-      unpack(response)
+      unpack { response }
     end
   end
 end

--- a/lib/scalingo/auth/two_factor_auth.rb
+++ b/lib/scalingo/auth/two_factor_auth.rb
@@ -16,7 +16,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :tfa)
+      unpack(:tfa) { response }
     end
 
     def initiate(provider = DEFAULT_PROVIDER, headers = nil, &block)
@@ -29,7 +29,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :tfa)
+      unpack(:tfa) { response }
     end
 
     def validate(attempt, headers = nil, &block)
@@ -42,7 +42,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :tfa)
+      unpack(:tfa) { response }
     end
 
     def disable(headers = nil, &block)
@@ -55,7 +55,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :tfa)
+      unpack(:tfa) { response }
     end
   end
 end

--- a/lib/scalingo/auth/user.rb
+++ b/lib/scalingo/auth/user.rb
@@ -12,7 +12,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :user)
+      unpack(:user) { response }
     end
 
     def update(payload, headers = nil, &block)
@@ -25,7 +25,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :user)
+      unpack(:user) { response }
     end
   end
 end

--- a/lib/scalingo/billing/profile.rb
+++ b/lib/scalingo/billing/profile.rb
@@ -12,7 +12,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :profile)
+      unpack(:profile) { response }
     end
 
     def create(payload = {}, headers = nil, &block)
@@ -25,7 +25,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :profile)
+      unpack(:profile) { response }
     end
 
     def update(id, payload = {}, headers = nil, &block)
@@ -38,7 +38,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :profile)
+      unpack(:profile) { response }
     end
 
     alias_method :self, :show

--- a/lib/scalingo/regional/addons.rb
+++ b/lib/scalingo/regional/addons.rb
@@ -12,7 +12,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :addons)
+      unpack(:addons) { response }
     end
 
     def find(app_id, addon_id, headers = nil, &block)
@@ -25,7 +25,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :addon)
+      unpack(:addon) { response }
     end
 
     def provision(app_id, payload = {}, headers = nil, &block)
@@ -38,7 +38,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :addon)
+      unpack(:addon) { response }
     end
 
     def update(app_id, addon_id, payload = {}, headers = nil, &block)
@@ -51,7 +51,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :addon)
+      unpack(:addon) { response }
     end
 
     def destroy(app_id, addon_id, headers = nil, &block)
@@ -64,7 +64,7 @@ module Scalingo
         &block
       )
 
-      unpack(response)
+      unpack { response }
     end
 
     def sso(app_id, addon_id, headers = nil, &block)
@@ -77,7 +77,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :addon)
+      unpack(:addon) { response }
     end
 
     def token(app_id, addon_id, headers = nil, &block)
@@ -90,7 +90,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :addon)
+      unpack(:addon) { response }
     end
 
     def categories(headers = nil, &block)
@@ -103,7 +103,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :addon_categories)
+      unpack(:addon_categories) { response }
     end
 
     def providers(headers = nil, &block)
@@ -116,7 +116,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :addon_providers)
+      unpack(:addon_providers) { response }
     end
   end
 end

--- a/lib/scalingo/regional/apps.rb
+++ b/lib/scalingo/regional/apps.rb
@@ -12,7 +12,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :apps)
+      unpack(:apps) { response }
     end
 
     def find(id, headers = nil, &block)
@@ -25,7 +25,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :app)
+      unpack(:app) { response }
     end
 
     def create(payload = {}, headers = nil, &block)
@@ -44,7 +44,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :app)
+      unpack(:app) { response }
     end
 
     def update(id, payload = {}, headers = nil, &block)
@@ -57,7 +57,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :app)
+      unpack(:app) { response }
     end
 
     def logs_url(id, headers = nil, &block)
@@ -70,7 +70,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :logs_url)
+      unpack(:logs_url) { response }
     end
 
     def destroy(id, payload = {}, headers = nil, &block)
@@ -81,7 +81,7 @@ module Scalingo
         &block
       )
 
-      unpack(response)
+      unpack { response }
     end
 
     def rename(id, payload = {}, headers = nil, &block)
@@ -92,7 +92,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :app)
+      unpack(:app) { response }
     end
 
     def transfer(id, payload = {}, headers = nil, &block)
@@ -103,7 +103,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :app)
+      unpack(:app) { response }
     end
   end
 end

--- a/lib/scalingo/regional/collaborators.rb
+++ b/lib/scalingo/regional/collaborators.rb
@@ -12,7 +12,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :collaborators)
+      unpack(:collaborators) { response }
     end
 
     def destroy(app_id, collaborator_id, headers = nil, &block)
@@ -25,7 +25,7 @@ module Scalingo
         &block
       )
 
-      unpack(response)
+      unpack { response }
     end
 
     def invite(app_id, payload = {}, headers = nil, &block)
@@ -38,7 +38,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :collaborator)
+      unpack(:collaborator) { response }
     end
 
     def accept(token, headers = nil, &block)
@@ -51,7 +51,7 @@ module Scalingo
         &block
       )
 
-      unpack(response)
+      unpack { response }
     end
   end
 end

--- a/lib/scalingo/regional/containers.rb
+++ b/lib/scalingo/regional/containers.rb
@@ -12,7 +12,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :containers)
+      unpack(:containers) { response }
     end
 
     def scale(app_id, formation, headers = nil, &block)
@@ -25,7 +25,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :containers)
+      unpack(:containers) { response }
     end
 
     def restart(app_id, scope = [], headers = nil, &block)
@@ -38,7 +38,7 @@ module Scalingo
         &block
       )
 
-      unpack(response)
+      unpack { response }
     end
 
     def sizes(headers = nil, &block)
@@ -51,7 +51,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :container_sizes)
+      unpack(:container_sizes) { response }
     end
   end
 end

--- a/lib/scalingo/regional/deployments.rb
+++ b/lib/scalingo/regional/deployments.rb
@@ -12,7 +12,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :deployments)
+      unpack(:deployments) { response }
     end
 
     def find(app_id, deployment_id, headers = nil, &block)
@@ -25,7 +25,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :deployment)
+      unpack(:deployment) { response }
     end
 
     def logs(app_id, deployment_id, headers = nil, &block)
@@ -38,7 +38,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :deployment)
+      unpack(:deployment) { response }
     end
   end
 end

--- a/lib/scalingo/regional/domains.rb
+++ b/lib/scalingo/regional/domains.rb
@@ -12,7 +12,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :domains)
+      unpack(:domains) { response }
     end
 
     def find(app_id, domain_id, headers = nil, &block)
@@ -25,7 +25,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :domain)
+      unpack(:domain) { response }
     end
 
     def create(app_id, payload = {}, headers = nil, &block)
@@ -38,7 +38,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :domain)
+      unpack(:domain) { response }
     end
 
     def update(app_id, domain_id, payload = {}, headers = nil, &block)
@@ -51,7 +51,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :domain)
+      unpack(:domain) { response }
     end
 
     def destroy(app_id, domain_id, headers = nil, &block)
@@ -64,7 +64,7 @@ module Scalingo
         &block
       )
 
-      unpack(response)
+      unpack { response }
     end
   end
 end

--- a/lib/scalingo/regional/environment.rb
+++ b/lib/scalingo/regional/environment.rb
@@ -12,7 +12,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :variables)
+      unpack(:variables) { response }
     end
 
     def create(app_id, payload = {}, headers = nil, &block)
@@ -25,7 +25,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :variable)
+      unpack(:variable) { response }
     end
 
     def update(app_id, variable_id, value, headers = nil, &block)
@@ -38,7 +38,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :variable)
+      unpack(:variable) { response }
     end
 
     def destroy(app_id, variable_id, headers = nil, &block)
@@ -51,7 +51,7 @@ module Scalingo
         &block
       )
 
-      unpack(response)
+      unpack { response }
     end
 
     def bulk_update(app_id, variables, headers = nil, &block)
@@ -64,7 +64,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :variables)
+      unpack(:variables) { response }
     end
 
     def bulk_destroy(app_id, variable_ids, headers = nil, &block)
@@ -77,7 +77,7 @@ module Scalingo
         &block
       )
 
-      unpack(response)
+      unpack { response }
     end
   end
 end

--- a/lib/scalingo/regional/events.rb
+++ b/lib/scalingo/regional/events.rb
@@ -10,7 +10,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :events)
+      unpack(:events) { response }
     end
 
     def for(app_id, payload = {}, headers = nil, &block)
@@ -23,7 +23,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :events)
+      unpack(:events) { response }
     end
 
     def types(headers = nil, &block)
@@ -36,7 +36,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :event_types)
+      unpack(:event_types) { response }
     end
 
     def categories(headers = nil, &block)
@@ -49,7 +49,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :event_categories)
+      unpack(:event_categories) { response }
     end
   end
 end

--- a/lib/scalingo/regional/logs.rb
+++ b/lib/scalingo/regional/logs.rb
@@ -10,7 +10,7 @@ module Scalingo
         &block
       )
 
-      unpack(response)
+      unpack { response }
     end
 
     def archives(app_id, headers = nil, &block)
@@ -23,7 +23,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :archives)
+      unpack(:archives) { response }
     end
 
     ## Helper method to avoid having to manually chain two operations

--- a/lib/scalingo/regional/metrics.rb
+++ b/lib/scalingo/regional/metrics.rb
@@ -22,7 +22,7 @@ module Scalingo
         &block
       )
 
-      unpack(response)
+      unpack { response }
     end
 
     def types(headers = nil, &block)
@@ -35,7 +35,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :metrics)
+      unpack(:metrics) { response }
     end
   end
 end

--- a/lib/scalingo/regional/notifiers.rb
+++ b/lib/scalingo/regional/notifiers.rb
@@ -12,7 +12,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :notifiers)
+      unpack(:notifiers) { response }
     end
 
     def find(app_id, notifier_id, headers = nil, &block)
@@ -25,7 +25,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :notifier)
+      unpack(:notifier) { response }
     end
 
     def create(app_id, payload = {}, headers = nil, &block)
@@ -38,7 +38,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :notifier)
+      unpack(:notifier) { response }
     end
 
     def update(app_id, notifier_id, payload = {}, headers = nil, &block)
@@ -51,7 +51,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :notifier)
+      unpack(:notifier) { response }
     end
 
     def destroy(app_id, notifier_id, headers = nil, &block)
@@ -64,7 +64,7 @@ module Scalingo
         &block
       )
 
-      unpack(response)
+      unpack { response }
     end
 
     def test(app_id, notifier_id, headers = nil, &block)
@@ -77,7 +77,7 @@ module Scalingo
         &block
       )
 
-      unpack(response)
+      unpack { response }
     end
 
     def platforms(headers = nil, &block)
@@ -90,7 +90,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :notification_platforms)
+      unpack(:notification_platforms) { response }
     end
   end
 end

--- a/lib/scalingo/regional/operations.rb
+++ b/lib/scalingo/regional/operations.rb
@@ -20,7 +20,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :operation)
+      unpack(:operation) { response }
     end
   end
 end

--- a/lib/scalingo/regional/scm_repo_links.rb
+++ b/lib/scalingo/regional/scm_repo_links.rb
@@ -12,7 +12,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :scm_repo_link)
+      unpack(:scm_repo_link) { response }
     end
 
     def create(app_id, payload = {}, headers = nil, &block)
@@ -25,7 +25,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :scm_repo_link)
+      unpack(:scm_repo_link) { response }
     end
 
     def update(app_id, payload = {}, headers = nil, &block)
@@ -38,7 +38,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :scm_repo_link)
+      unpack(:scm_repo_link) { response }
     end
 
     def destroy(app_id, headers = nil, &block)
@@ -51,7 +51,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :scm_repo_link)
+      unpack(:scm_repo_link) { response }
     end
 
     def deploy(app_id, branch, headers = nil, &block)
@@ -64,7 +64,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :deployment)
+      unpack(:deployment) { response }
     end
 
     def review_app(review_app, pull_request_id, headers = nil, &block)
@@ -77,7 +77,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :review_app)
+      unpack(:review_app) { response }
     end
 
     def branches(app_id, headers = nil, &block)
@@ -90,7 +90,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :branches)
+      unpack(:branches) { response }
     end
 
     def pulls(app_id, headers = nil, &block)
@@ -103,7 +103,7 @@ module Scalingo
         &block
       )
 
-      unpack(response, key: :pulls)
+      unpack(:pulls) { response }
     end
   end
 end

--- a/spec/scalingo/api/endpoint_spec.rb
+++ b/spec/scalingo/api/endpoint_spec.rb
@@ -22,9 +22,10 @@ RSpec.describe Scalingo::API::Endpoint do
 
   describe "unpack" do
     it "forwards unpack to Response" do
-      expect(Scalingo::API::Response).to receive(:unpack).with(client, :a, :b, :c).and_return(:d).once
+      mock = proc { 1 }
 
-      expect(subject.send(:unpack, :a, :b, :c)).to eq :d
+      expect(Scalingo::API::Response).to receive(:unpack).with(client, key: :a, &mock).and_return(:d).once
+      expect(subject.send(:unpack, :a, &mock)).to eq :d
     end
   end
 end

--- a/spec/scalingo/api/response_spec.rb
+++ b/spec/scalingo/api/response_spec.rb
@@ -33,19 +33,19 @@ RSpec.describe Scalingo::API::Response do
     }
 
     it "passes the client supplied" do
-      object = described_class.unpack(:some_client, response)
+      object = described_class.unpack(:some_client) { response }
 
       expect(object.client).to eq :some_client
     end
 
     it "passes the response status" do
-      object = described_class.unpack(:client, response)
+      object = described_class.unpack(:client) { response }
 
       expect(object.status).to eq status
     end
 
     it "passes the response headers" do
-      object = described_class.unpack(:client, response)
+      object = described_class.unpack(:client) { response }
 
       expect(object.headers).to eq headers
     end
@@ -54,7 +54,7 @@ RSpec.describe Scalingo::API::Response do
       let(:body) { "" }
 
       it "without key" do
-        object = described_class.unpack(client, response)
+        object = described_class.unpack(client) { response }
 
         expect(object.data).to eq ""
         expect(object.full_body).to eq ""
@@ -62,7 +62,7 @@ RSpec.describe Scalingo::API::Response do
       end
 
       it "ignores key if supplied" do
-        object = described_class.unpack(client, response, key: :key)
+        object = described_class.unpack(client, key: :key) { response }
 
         expect(object.data).to eq ""
         expect(object.full_body).to eq ""
@@ -74,7 +74,7 @@ RSpec.describe Scalingo::API::Response do
       let(:body) { nil }
 
       it "without key" do
-        object = described_class.unpack(client, response)
+        object = described_class.unpack(client) { response }
 
         expect(object.data).to eq nil
         expect(object.full_body).to eq nil
@@ -82,7 +82,7 @@ RSpec.describe Scalingo::API::Response do
       end
 
       it "ignores key if supplied" do
-        object = described_class.unpack(client, response, key: :key)
+        object = described_class.unpack(client, key: :key) { response }
 
         expect(object.data).to eq nil
         expect(object.full_body).to eq nil
@@ -94,7 +94,7 @@ RSpec.describe Scalingo::API::Response do
       let(:body) { "this is a string body, probably due to an error" }
 
       it "without key" do
-        object = described_class.unpack(client, response)
+        object = described_class.unpack(client) { response }
 
         expect(object.data).to eq body
         expect(object.full_body).to eq body
@@ -102,7 +102,7 @@ RSpec.describe Scalingo::API::Response do
       end
 
       it "ignores key if supplied" do
-        object = described_class.unpack(client, response, key: :key)
+        object = described_class.unpack(client, key: :key) { response }
 
         expect(object.data).to eq body
         expect(object.full_body).to eq body
@@ -116,7 +116,7 @@ RSpec.describe Scalingo::API::Response do
       }
 
       it "without key" do
-        object = described_class.unpack(client, response)
+        object = described_class.unpack(client) { response }
 
         expect(object.data).to eq body
         expect(object.full_body).to eq body
@@ -124,7 +124,7 @@ RSpec.describe Scalingo::API::Response do
       end
 
       it "ignores key if supplied" do
-        object = described_class.unpack(client, response, key: :root)
+        object = described_class.unpack(client, key: :root) { response }
 
         expect(object.data).to eq body
         expect(object.full_body).to eq body
@@ -138,7 +138,7 @@ RSpec.describe Scalingo::API::Response do
       }
 
       it "without key" do
-        object = described_class.unpack(client, response)
+        object = described_class.unpack(client) { response }
 
         expect(object.data).to eq body
         expect(object.full_body).to eq body
@@ -146,7 +146,7 @@ RSpec.describe Scalingo::API::Response do
       end
 
       it "with valid key" do
-        object = described_class.unpack(client, response, key: :root)
+        object = described_class.unpack(client, key: :root) { response }
 
         expect(object.data).to eq({key: :value})
         expect(object.full_body).to eq body
@@ -154,7 +154,7 @@ RSpec.describe Scalingo::API::Response do
       end
 
       it "with invalid key" do
-        object = described_class.unpack(client, response, key: :other)
+        object = described_class.unpack(client, key: :other) { response }
 
         expect(object.data).to eq nil
         expect(object.full_body).to eq body
@@ -167,7 +167,7 @@ RSpec.describe Scalingo::API::Response do
         }
 
         it "extracts the meta object" do
-          object = described_class.unpack(client, response)
+          object = described_class.unpack(client) { response }
 
           expect(object.meta).to eq({meta1: :value})
         end
@@ -179,7 +179,7 @@ RSpec.describe Scalingo::API::Response do
       let(:body) { {root: {key: :value}} }
 
       it "does not dig in the response hash, even with a valid key" do
-        object = described_class.unpack(client, response, key: :root)
+        object = described_class.unpack(client, key: :root) { response }
 
         expect(object.data).to eq body
         expect(object.full_body).to eq body


### PR DESCRIPTION
Fix #21 

Changes an internal API, `unpack`. The response is now supplied as the return value of a block in order to catch exceptions. Current use case is handling timeout responses.

First commits switches to the new version of `unpack`, second leverages it to handle timeouts.