### PR TITLE
Support ActiveSupport 7

### DIFF
--- a/lib/scalingo/configuration.rb
+++ b/lib/scalingo/configuration.rb
@@ -1,3 +1,4 @@
+require "active_support"
 require "active_support/core_ext/numeric/time"
 require "scalingo/version"
 require "ostruct"

--- a/lib/scalingo/regional/metrics.rb
+++ b/lib/scalingo/regional/metrics.rb
@@ -1,4 +1,5 @@
 require "scalingo/api/endpoint"
+require "active_support"
 require "active_support/core_ext/hash/indifferent_access"
 
 module Scalingo

--- a/scalingo.gemspec
+++ b/scalingo.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
 
   s.test_files = Dir["spec/**/*_spec.rb"]
 
-  s.add_dependency "activesupport", [">= 5", "< 7"]
+  s.add_dependency "activesupport", [">= 5", "< 8"]
   s.add_dependency "faraday", "~> 1.0"
   s.add_dependency "faraday_middleware", "~> 1.0"
   s.add_dependency "multi_json", ">= 1.0.3", "~> 1.0"


### PR DESCRIPTION
Rails 7 was just released, this PR relaxes the dependency on active support to be able to cohabit with a rails 7 app.

The test matrix doesn't test different versions of active support, maybe that would be an interesting thing to do ? Anyway I tested locally on AS 7.0.

Also fixing active support requires, see rails/rails#43889