### PR TITLE
feat(dependabot): Monthly + ksol assigned to review as owner of the project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    reviewers:
+      - "ksol"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,7 +1,3 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
 # This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
 # For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
 


### PR DESCRIPTION
I just noticed there are some GitHub Action but we don't update them. We could activate Dependabot to update the GitHub Actions we use.