### PR TITLE
chore(release): Bump gem to v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 4.0.0
+
 * Removal: `Scalingo::Client#agora_fr1` had been removed since the region no longer exists.
 * New: Add `addons#authenticate!` endpoint
 * New API: database API

--- a/lib/scalingo/version.rb
+++ b/lib/scalingo/version.rb
@@ -1,3 +1,3 @@
 module Scalingo
-  VERSION = "3.1.0"
+  VERSION = "4.0.0"
 end


### PR DESCRIPTION
Fix. https://github.com/Scalingo/scalingo-ruby-api/issues/28