### PR TITLE
Rubocop-rspec + code coverage

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ require:
   - standard-custom
   - standard-performance
   - rubocop-performance
+  - rubocop-rspec
 
 inherit_gem:
   standard: config/base.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,3 +19,43 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
     - '.git/**/*'
+
+# Line-base counting is not reliable enough
+RSpec/ExampleLength:
+  Enabled: false
+
+# Deprecated cop, will be removed
+RSpec/FilePath:
+  Enabled: false
+
+# Not convinced by how strict this cop is by default
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
+# Really not convinced by this one
+RSpec/NamedSubject:
+  Enabled: false
+
+# Default is 3, but 4 is used and relevant (class / method / global state / local state)
+RSpec/NestedGroups:
+  Max: 4
+
+# Not always relevant for libs
+RSpec/SpecFilePathFormat:
+  Exclude:
+    - 'spec/scalingo/faraday/**/*'
+
+# Not sure about this one - requires more research
+RSpec/MessageSpies:
+  Enabled: false
+
+# Not sure about this one - requires more research
+RSpec/StubbedMock:
+  Enabled: false
+
+# Not sure about this one - requires more research
+RSpec/SubjectStub:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in scalingo.gemspec
 gemspec
+
+gem "simplecov"

--- a/README.md
+++ b/README.md
@@ -2,13 +2,8 @@
 
 A ruby wrapper for the Scalingo API
 
-### Migration from v2
-
-This gem is changing its name from `scalingo-ruby-api` to `scalingo`,
-and the versioning does **not** reset; the first major version of `scalingo`
-will therefore be `3.x.x`.
-
-You can check the version 2 at [the v2 branch of this repository](https://github.com/Scalingo/scalingo-ruby-api/tree/v2)
+> [!WARNING]
+> `master` is under development and contains yet-to-be-documented breaking changes. The readme is about the stable v3 interface.
 
 ## Installation
 

--- a/lib/scalingo/api/client.rb
+++ b/lib/scalingo/api/client.rb
@@ -44,6 +44,7 @@ module Scalingo
         end
       end
 
+      # :nocov:
       def inspect
         str = %(<#{self.class}:0x#{object_id.to_s(16)} url:"#{@url}" methods:)
 
@@ -51,6 +52,7 @@ module Scalingo
         str << ">"
         str
       end
+      # :nocov:
 
       ## Faraday objects
       def headers

--- a/lib/scalingo/api/endpoint.rb
+++ b/lib/scalingo/api/endpoint.rb
@@ -98,6 +98,7 @@ module Scalingo
         end
       end
 
+      # :nocov:
       def inspect
         str = %(<#{self.class}:0x#{object_id.to_s(16)} base_url:"#{@client.url}" endpoints:)
 
@@ -105,6 +106,7 @@ module Scalingo
         str << ">"
         str
       end
+      # :nocov:
     end
   end
 end

--- a/lib/scalingo/bearer_token.rb
+++ b/lib/scalingo/bearer_token.rb
@@ -9,6 +9,7 @@ module Scalingo
       @raise_on_expired = raise_on_expired
     end
 
+    # :nocov:
     def inspect
       str = "<#{self.class}:0x#{object_id.to_s(16)} "
 
@@ -23,6 +24,7 @@ module Scalingo
       str << %(value:"#{value}">)
       str
     end
+    # :nocov:
 
     def raise_on_expired?
       @raise_on_expired

--- a/lib/scalingo/core_client.rb
+++ b/lib/scalingo/core_client.rb
@@ -14,6 +14,7 @@ module Scalingo
       @config = Configuration.new(attributes, Scalingo.config)
     end
 
+    # :nocov:
     def inspect
       str = %(<#{self.class}:0x#{object_id.to_s(16)} version:"#{Scalingo::VERSION}" authenticated:)
 
@@ -26,6 +27,7 @@ module Scalingo
       str << ">"
       str
     end
+    # :nocov:
 
     ## Sub-clients accessors
     def auth

--- a/spec/scalingo/api/client_spec.rb
+++ b/spec/scalingo/api/client_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 RSpec.describe Scalingo::API::Client do
+  subject { described_class.new(url, scalingo: scalingo) }
+
   let(:url) { "http://localhost" }
   let(:bearer_token) { "bearer-token" }
   let(:scalingo) do
@@ -8,8 +10,6 @@ RSpec.describe Scalingo::API::Client do
     scalingo_client.authenticate_with(bearer_token: bearer_token) if bearer_token
     scalingo_client
   end
-
-  subject { described_class.new(url, scalingo: scalingo) }
 
   describe "initialize" do
     let(:config) { {default_region: :test} }

--- a/spec/scalingo/api/client_spec.rb
+++ b/spec/scalingo/api/client_spec.rb
@@ -5,8 +5,9 @@ RSpec.describe Scalingo::API::Client do
 
   let(:url) { "http://localhost" }
   let(:bearer_token) { "bearer-token" }
+  let(:configuration) { {} }
   let(:scalingo) do
-    scalingo_client = Scalingo::Client.new
+    scalingo_client = Scalingo::Client.new(configuration)
     scalingo_client.authenticate_with(bearer_token: bearer_token) if bearer_token
     scalingo_client
   end
@@ -98,10 +99,7 @@ RSpec.describe Scalingo::API::Client do
   end
 
   describe "headers" do
-    before do
-      allow(scalingo.config).to receive(:user_agent).and_return(user_agent)
-    end
-
+    let(:configuration) { {user_agent: user_agent} }
     let(:user_agent) { "user agent" }
     let(:extra_hash) { {"X-Other" => "other"} }
     let(:extra_block) {

--- a/spec/scalingo/api/client_spec.rb
+++ b/spec/scalingo/api/client_spec.rb
@@ -85,11 +85,11 @@ RSpec.describe Scalingo::API::Client do
       expect(mock).to receive(:new).with(instance).and_return("1st").once
 
       # Not yet loaded...
-      expect(instance.instance_variable_get(:@handler)).to eq(nil)
+      expect(instance.instance_variable_get(:@handler)).to be_nil
       instance.handler
 
       # Memoized...
-      expect(instance.instance_variable_get(:@handler)).not_to eq(nil)
+      expect(instance.instance_variable_get(:@handler)).not_to be_nil
 
       # More calls won't try to perform more instanciations
       instance.handler

--- a/spec/scalingo/api/client_spec.rb
+++ b/spec/scalingo/api/client_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Scalingo::API::Client do
 
   describe "headers" do
     before do
-      expect(scalingo.config).to receive(:user_agent).and_return(user_agent).once
+      allow(scalingo.config).to receive(:user_agent).and_return(user_agent)
     end
 
     let(:user_agent) { "user agent" }
@@ -229,8 +229,8 @@ RSpec.describe Scalingo::API::Client do
   end
 
   describe "connection" do
-    context "logged" do
-      context "no fallback to guest" do
+    context "when logged" do
+      context "without fallback to guest" do
         it "calls and return the authenticated_connection" do
           expect(subject).to receive(:authenticated_connection).and_return(:conn)
           expect(subject.connection).to eq(:conn)
@@ -245,10 +245,10 @@ RSpec.describe Scalingo::API::Client do
       end
     end
 
-    context "not logged" do
+    context "when not logged" do
       let(:bearer_token) { nil }
 
-      context "no fallback to guest" do
+      context "without fallback to guest" do
         it "raises when set to raise" do
           expect(scalingo.config).to receive(:raise_on_missing_authentication).and_return(true).once
 

--- a/spec/scalingo/api/endpoint_spec.rb
+++ b/spec/scalingo/api/endpoint_spec.rb
@@ -1,9 +1,9 @@
 require "spec_helper"
 
 RSpec.describe Scalingo::API::Endpoint do
-  let(:client) { double }
-
   subject { described_class.new(client) }
+
+  let(:client) { double }
 
   describe "initialize" do
     it "stores the client" do

--- a/spec/scalingo/bearer_token_spec.rb
+++ b/spec/scalingo/bearer_token_spec.rb
@@ -1,11 +1,11 @@
 require "spec_helper"
 
 RSpec.describe Scalingo::BearerToken do
+  subject { described_class.new(value, expires_at: expires_at, raise_on_expired: raise_on_expired) }
+
   let(:value) { "my-token" }
   let(:expires_at) { nil }
   let(:raise_on_expired) { false }
-
-  subject { described_class.new(value, expires_at: expires_at, raise_on_expired: raise_on_expired) }
 
   describe "initialize" do
     it "stores the value" do
@@ -31,11 +31,13 @@ RSpec.describe Scalingo::BearerToken do
 
     context "with the expiration in the future" do
       let(:expires_at) { Time.current + 1.hour }
+
       it { expect(subject).not_to be_expired }
     end
 
     context "with the expiration in the past" do
       let(:expires_at) { Time.current - 1.minute }
+
       it { expect(subject).to be_expired }
     end
   end

--- a/spec/scalingo/bearer_token_spec.rb
+++ b/spec/scalingo/bearer_token_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Scalingo::BearerToken do
       instance = described_class.new(:value)
 
       expect(instance.value).to eq(:value)
-      expect(instance.expires_at).to eq nil
+      expect(instance.expires_at).to be_nil
     end
 
     it "stores the expiration" do

--- a/spec/scalingo/client_spec.rb
+++ b/spec/scalingo/client_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Scalingo::Client do
 
   describe "token" do
     it "wraps the token in a BearerToken" do
-      expect(subject.token).to eq nil
+      expect(subject.token).to be_nil
 
       subject.token = "my-token"
       expect(subject.token).to be_a(Scalingo::BearerToken)
@@ -78,15 +78,15 @@ RSpec.describe Scalingo::Client do
       it "only sets the bearer token according to the arguments" do
         expect(subject.authenticate_with(bearer_token: "my token")).to be true
         expect(subject.token.value).to eq "my token"
-        expect(subject.token.expires_at).to eq nil
+        expect(subject.token.expires_at).to be_nil
 
         expect(subject.authenticate_with(bearer_token: Scalingo::BearerToken.new("my token"))).to be true
         expect(subject.token.value).to eq "my token"
-        expect(subject.token.expires_at).to eq nil
+        expect(subject.token.expires_at).to be_nil
 
         expect(subject.authenticate_with(bearer_token: "my token", expires_at: Time.now + 1.hour)).to be true
         expect(subject.token.value).to eq "my token"
-        expect(subject.token.expires_at).not_to eq nil
+        expect(subject.token.expires_at).not_to be_nil
       end
     end
   end

--- a/spec/scalingo/client_spec.rb
+++ b/spec/scalingo/client_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Scalingo::Client do
         expect(subject.auth.tokens).to receive(:exchange).and_return(fake_response)
 
         expect(subject.authenticate_with(access_token: "access token")).to be false
-        expect(subject.token).to be nil
+        expect(subject.token).to be_nil
       end
     end
 

--- a/spec/scalingo/faraday/extract_meta_spec.rb
+++ b/spec/scalingo/faraday/extract_meta_spec.rb
@@ -13,6 +13,8 @@ RSpec.shared_examples "no meta extraction" do
 end
 
 RSpec.describe Scalingo::ExtractMeta do
+  subject { client.get("/") }
+
   let(:headers) { {"Content-Type" => content_type}.compact }
   let(:content_type) { "application/json" }
   let(:body) { nil }
@@ -26,8 +28,6 @@ RSpec.describe Scalingo::ExtractMeta do
       end
     end
   end
-
-  subject { client.get("/") }
 
   context "with a non-json response" do
     let(:content_type) { "text/html" }

--- a/spec/scalingo/faraday/extract_meta_spec.rb
+++ b/spec/scalingo/faraday/extract_meta_spec.rb
@@ -3,12 +3,12 @@ require "scalingo/faraday/extract_meta"
 
 RSpec.shared_examples "no meta extraction" do
   it "does not extract meta from response" do
-    expect(subject.meta).to eq(nil)
-    expect(subject.meta?).to eq(false)
-    expect(subject.pagination).to eq(nil)
-    expect(subject.paginated?).to eq(false)
-    expect(subject.cursor_pagination).to eq(nil)
-    expect(subject.cursor_paginated?).to eq(false)
+    expect(subject.meta).to be_nil
+    expect(subject.meta?).to be(false)
+    expect(subject.pagination).to be_nil
+    expect(subject.paginated?).to be(false)
+    expect(subject.cursor_pagination).to be_nil
+    expect(subject.cursor_paginated?).to be(false)
   end
 end
 
@@ -64,11 +64,11 @@ RSpec.describe Scalingo::ExtractMeta do
 
       it "extracts the meta" do
         expect(subject.meta).to eq({a: 1})
-        expect(subject.meta?).to eq(true)
-        expect(subject.pagination).to eq(nil)
-        expect(subject.paginated?).to eq(false)
-        expect(subject.cursor_pagination).to eq(nil)
-        expect(subject.cursor_paginated?).to eq(false)
+        expect(subject.meta?).to be(true)
+        expect(subject.pagination).to be_nil
+        expect(subject.paginated?).to be(false)
+        expect(subject.cursor_pagination).to be_nil
+        expect(subject.cursor_paginated?).to be(false)
       end
     end
 
@@ -77,11 +77,11 @@ RSpec.describe Scalingo::ExtractMeta do
 
       it "extracts the meta" do
         expect(subject.meta).to eq({pagination: {page: 1}})
-        expect(subject.meta?).to eq(true)
+        expect(subject.meta?).to be(true)
         expect(subject.pagination).to eq({page: 1})
-        expect(subject.paginated?).to eq(true)
-        expect(subject.cursor_pagination).to eq(nil)
-        expect(subject.cursor_paginated?).to eq(false)
+        expect(subject.paginated?).to be(true)
+        expect(subject.cursor_pagination).to be_nil
+        expect(subject.cursor_paginated?).to be(false)
       end
     end
 
@@ -90,11 +90,11 @@ RSpec.describe Scalingo::ExtractMeta do
 
       it "extracts the meta" do
         expect(subject.meta).to eq({cursor_pagination: {next_cursor: 1, has_more: true}})
-        expect(subject.meta?).to eq(true)
-        expect(subject.pagination).to eq(nil)
-        expect(subject.paginated?).to eq(false)
+        expect(subject.meta?).to be(true)
+        expect(subject.pagination).to be_nil
+        expect(subject.paginated?).to be(false)
         expect(subject.cursor_pagination).to eq({next_cursor: 1, has_more: true})
-        expect(subject.cursor_paginated?).to eq(true)
+        expect(subject.cursor_paginated?).to be(true)
       end
     end
   end

--- a/spec/scalingo/faraday/extract_root_value_spec.rb
+++ b/spec/scalingo/faraday/extract_root_value_spec.rb
@@ -2,6 +2,8 @@ require "spec_helper"
 require "scalingo/faraday/extract_root_value"
 
 RSpec.describe Scalingo::ExtractRootValue do
+  subject { client.get("/") }
+
   let(:status) { 200 }
   let(:body) { {a: 1} }
 
@@ -13,8 +15,6 @@ RSpec.describe Scalingo::ExtractRootValue do
       end
     end
   end
-
-  subject { client.get("/") }
 
   context "with a non-successful response" do
     let(:status) { 300 }

--- a/spec/scalingo/regional/logs_spec.rb
+++ b/spec/scalingo/regional/logs_spec.rb
@@ -37,10 +37,10 @@ RSpec.describe Scalingo::Regional::Logs, type: :endpoint do
   describe "for" do
     subject(:response) { instance.for(**arguments) }
 
+    let(:params) { {app_id: app_id} }
+
     include_examples "requires authentication"
     include_examples "requires some params", :app_id
-
-    let(:params) { {app_id: app_id} }
 
     context "with a successful call for the logs url" do
       before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,15 @@
 require "bundler/setup"
-require "scalingo"
 require "active_support/all"
+
+if ENV["COVERAGE"]
+  require "simplecov"
+
+  SimpleCov.start do
+    enable_coverage :branch
+  end
+end
+
+require "scalingo"
 
 pattern = File.join(File.expand_path(__dir__), "support", "**", "*.rb")
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  config.include_context "default endpoint context", type: :endpoint
+  config.include_context "with the default endpoint context", type: :endpoint
 
   config.before(:each, type: :endpoint) do
     stub_request(:any, /localhost/)

--- a/spec/support/shared.rb
+++ b/spec/support/shared.rb
@@ -1,4 +1,4 @@
-RSpec.shared_context "default endpoint context" do
+RSpec.shared_context "with the default endpoint context" do
   subject do
     response # need to be defined in the including context
     WebMock # returning this lets us use the one-liner `have_requested` syntax

--- a/spec/support/shared.rb
+++ b/spec/support/shared.rb
@@ -1,4 +1,9 @@
 RSpec.shared_context "default endpoint context" do
+  subject do
+    response # need to be defined in the including context
+    WebMock # returning this lets us use the one-liner `have_requested` syntax
+  end
+
   let(:bearer_token) { "Bearer token" }
 
   let(:arguments) do
@@ -22,11 +27,6 @@ RSpec.shared_context "default endpoint context" do
 
   let(:api_client) { described_class.module_parent.new(api_path.to_s, scalingo: scalingo_client) }
   let(:instance) { described_class.new(api_client) }
-
-  subject do
-    response # need to be defined in the including context
-    WebMock # returning this lets us use the one-liner `have_requested` syntax
-  end
 end
 
 RSpec.shared_examples "requires authentication" do


### PR DESCRIPTION
Adds rubocop-rspec, fixes some violations, ignores others - I really wish standardrb would propose a standard-rspec, fine-tuning these rules is not fun. In the meantime, this seems like a balanced improvement.

Adds optional coverage generation too