### PR TITLE
Method naming conventions

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+bundle exec rubocop $@

--- a/bin/setup
+++ b/bin/setup
@@ -1,8 +1,23 @@
-#!/usr/bin/env bash
-set -euo pipefail
-IFS=$'\n\t'
-set -vx
+#!/usr/bin/env ruby
+require "fileutils"
 
-bundle install
+# path to your application root.
+GEM_ROOT = File.expand_path("..", __dir__)
 
-# Do any other automated setup that you need to do here
+def system!(*args)
+  system(*args, exception: true)
+end
+
+FileUtils.chdir GEM_ROOT do
+  # This script is a way to set up or update your development environment automatically.
+  # This script is idempotent, so that you can run it at any time and get an expectable outcome.
+  # Add necessary setup steps to this file.
+
+  puts "== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
+
+  # Creating useful but unversioned env files
+  puts "\n== Creating .env.*.local files =="
+  FileUtils.touch(".env.local")
+end

--- a/bin/specs
+++ b/bin/specs
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+bundle exec rspec $@

--- a/lib/scalingo/auth/keys.rb
+++ b/lib/scalingo/auth/keys.rb
@@ -2,9 +2,9 @@ require "scalingo/api/endpoint"
 
 module Scalingo
   class Auth::Keys < API::Endpoint
-    get :all, "keys"
-    get :show, "keys/{id}"
+    get :list, "keys"
+    get :find, "keys/{id}"
     post :create, "keys", root_key: :key
-    delete :destroy, "keys/{id}"
+    delete :delete, "keys/{id}"
   end
 end

--- a/lib/scalingo/auth/scm_integrations.rb
+++ b/lib/scalingo/auth/scm_integrations.rb
@@ -2,9 +2,9 @@ require "scalingo/api/endpoint"
 
 module Scalingo
   class Auth::ScmIntegrations < API::Endpoint
-    get :all, "scm_integrations"
-    get :show, "scm_integrations/{id}"
+    get :list, "scm_integrations"
+    get :find, "scm_integrations/{id}"
     post :create, "scm_integrations", root_key: :scm_integration
-    delete :destroy, "scm_integrations/{id}"
+    delete :delete, "scm_integrations/{id}"
   end
 end

--- a/lib/scalingo/auth/tokens.rb
+++ b/lib/scalingo/auth/tokens.rb
@@ -2,10 +2,10 @@ require "scalingo/api/endpoint"
 
 module Scalingo
   class Auth::Tokens < API::Endpoint
-    post :exchange, "tokens/exchange", connected: false
-    get :all, "tokens"
+    get :list, "tokens"
     post :create, "tokens", root_key: :token
-    patch :renew, "tokens/{id}/renew"
-    delete :destroy, "tokens/{id}"
+    delete :delete, "tokens/{id}"
+    post :exchange, "tokens/exchange", connected: false
+    put :renew, "tokens/{id}/renew"
   end
 end

--- a/lib/scalingo/auth/user.rb
+++ b/lib/scalingo/auth/user.rb
@@ -2,7 +2,7 @@ require "scalingo/api/endpoint"
 
 module Scalingo
   class Auth::User < API::Endpoint
-    get :self, "users/self"
+    get :find, "users/self"
     put :update, "users/account", root_key: :user
     post :stop_free_trial, "users/stop_free_trial"
   end

--- a/lib/scalingo/billing/profile.rb
+++ b/lib/scalingo/billing/profile.rb
@@ -5,7 +5,5 @@ module Scalingo
     get :find, "profile"
     post :create, "profiles", root_key: :profile
     put :update, "profiles/{id}", root_key: :profile
-
-    alias_method :self, :show
   end
 end

--- a/lib/scalingo/billing/profile.rb
+++ b/lib/scalingo/billing/profile.rb
@@ -2,7 +2,7 @@ require "scalingo/api/endpoint"
 
 module Scalingo
   class Billing::Profile < API::Endpoint
-    get :show, "profile"
+    get :find, "profile"
     post :create, "profiles", root_key: :profile
     put :update, "profiles/{id}", root_key: :profile
 

--- a/lib/scalingo/client.rb
+++ b/lib/scalingo/client.rb
@@ -50,5 +50,10 @@ module Scalingo
         scalingo: self
       )
     end
+
+    ## Helpers
+    def self
+      auth.user.find
+    end
   end
 end

--- a/lib/scalingo/regional/addons.rb
+++ b/lib/scalingo/regional/addons.rb
@@ -2,11 +2,11 @@ require "scalingo/api/endpoint"
 
 module Scalingo
   class Regional::Addons < API::Endpoint
-    get :for, "apps/{app_id}/addons"
+    get :list, "apps/{app_id}/addons"
     get :find, "apps/{app_id}/addons/{id}"
-    post :provision, "apps/{app_id}/addons", root_key: :addon
-    patch :update, "apps/{app_id}/addons/{id}", root_key: :addon
-    delete :destroy, "apps/{app_id}/addons/{id}"
+    post :create, "apps/{app_id}/addons", root_key: :addon
+    put :update, "apps/{app_id}/addons/{id}", root_key: :addon
+    delete :delete, "apps/{app_id}/addons/{id}"
     get :sso, "apps/{app_id}/addons/{id}/sso"
     post :token, "apps/{app_id}/addons/{id}/token"
     get :categories, "addon_categories", connected: false

--- a/lib/scalingo/regional/apps.rb
+++ b/lib/scalingo/regional/apps.rb
@@ -2,16 +2,15 @@ require "scalingo/api/endpoint"
 
 module Scalingo
   class Regional::Apps < API::Endpoint
-    get :all, "apps"
+    get :list, "apps"
     get :find, "apps/{id}"
-    get :logs_url, "apps/{id}/logs"
-    post :rename, "apps/{id}/rename"
-    patch :update, "apps/{id}", root_key: :app
-    patch :transfer, "apps/{id}"
-    delete :destroy, "apps/{id}"
-
     post :create, "apps", root_key: :app do |req, params|
       req.headers["X-Dry-Run"] = "true" if params[:dry_run]
     end
+    put :update, "apps/{id}", root_key: :app
+    delete :delete, "apps/{id}"
+    get :logs_url, "apps/{id}/logs"
+    post :rename, "apps/{id}/rename"
+    put :transfer, "apps/{id}"
   end
 end

--- a/lib/scalingo/regional/autoscalers.rb
+++ b/lib/scalingo/regional/autoscalers.rb
@@ -2,10 +2,10 @@ require "scalingo/api/endpoint"
 
 module Scalingo
   class Regional::Autoscalers < API::Endpoint
-    get :for, "apps/{app_id}/autoscalers"
+    get :list, "apps/{app_id}/autoscalers"
     get :find, "apps/{app_id}/autoscalers/{id}"
     post :create, "apps/{app_id}/autoscalers", root_key: :autoscaler
-    patch :update, "apps/{app_id}/autoscalers/{id}", root_key: :autoscaler
-    delete :destroy, "apps/{app_id}/autoscalers/{id}"
+    put :update, "apps/{app_id}/autoscalers/{id}", root_key: :autoscaler
+    delete :delete, "apps/{app_id}/autoscalers/{id}"
   end
 end

--- a/lib/scalingo/regional/collaborators.rb
+++ b/lib/scalingo/regional/collaborators.rb
@@ -2,9 +2,9 @@ require "scalingo/api/endpoint"
 
 module Scalingo
   class Regional::Collaborators < API::Endpoint
-    get :for, "apps/{app_id}/collaborators"
+    get :list, "apps/{app_id}/collaborators"
+    post :create, "apps/{app_id}/collaborators", root_key: "collaborator"
+    delete :delete, "apps/{app_id}/collaborators/{id}"
     get :accept, "apps/collaboration?token={token}"
-    post :invite, "apps/{app_id}/collaborators", root_key: "collaborator"
-    delete :destroy, "apps/{app_id}/collaborators/{id}"
   end
 end

--- a/lib/scalingo/regional/containers.rb
+++ b/lib/scalingo/regional/containers.rb
@@ -2,7 +2,7 @@ require "scalingo/api/endpoint"
 
 module Scalingo
   class Regional::Containers < API::Endpoint
-    get :for, "apps/{app_id}/containers"
+    get :list, "apps/{app_id}/containers"
     post :scale, "apps/{app_id}/scale", root_key: :containers
     post :restart, "apps/{app_id}/restart", root_key: :scope
     get :sizes, "features/container_sizes"

--- a/lib/scalingo/regional/deployments.rb
+++ b/lib/scalingo/regional/deployments.rb
@@ -2,7 +2,7 @@ require "scalingo/api/endpoint"
 
 module Scalingo
   class Regional::Deployments < API::Endpoint
-    get :for, "apps/{app_id}/deployments{?query*}", optional: [:query]
+    get :list, "apps/{app_id}/deployments{?query*}", optional: [:query]
     get :find, "apps/{app_id}/deployments/{id}"
     get :logs, "apps/{app_id}/deployments/{id}/output"
   end

--- a/lib/scalingo/regional/domains.rb
+++ b/lib/scalingo/regional/domains.rb
@@ -2,10 +2,10 @@ require "scalingo/api/endpoint"
 
 module Scalingo
   class Regional::Domains < API::Endpoint
-    get :for, "apps/{app_id}/domains"
+    get :list, "apps/{app_id}/domains"
     get :find, "apps/{app_id}/domains/{id}"
     post :create, "apps/{app_id}/domains", root_key: :domain
-    patch :update, "apps/{app_id}/domains/{id}", root_key: :domain
-    delete :destroy, "apps/{app_id}/domains/{id}"
+    put :update, "apps/{app_id}/domains/{id}", root_key: :domain
+    delete :delete, "apps/{app_id}/domains/{id}"
   end
 end

--- a/lib/scalingo/regional/environment.rb
+++ b/lib/scalingo/regional/environment.rb
@@ -2,11 +2,11 @@ require "scalingo/api/endpoint"
 
 module Scalingo
   class Regional::Environment < API::Endpoint
-    get :for, "apps/{app_id}/variables"
+    get :list, "apps/{app_id}/variables"
     post :create, "apps/{app_id}/variables", root_key: :variable
-    patch :update, "apps/{app_id}/variables/{id}", root_key: :variable
+    put :update, "apps/{app_id}/variables/{id}", root_key: :variable
+    delete :delete, "apps/{app_id}/variables/{id}"
     put :bulk_update, "apps/{app_id}/variables", root_key: :variables
-    delete :destroy, "apps/{app_id}/variables/{id}"
     delete :bulk_destroy, "apps/{app_id}/variables", root_key: :variable_ids, params_as_body: true
   end
 end

--- a/lib/scalingo/regional/events.rb
+++ b/lib/scalingo/regional/events.rb
@@ -1,7 +1,9 @@
 module Scalingo
   class Regional::Events < API::Endpoint
-    get :all, "events{?query*}", optional: [:query]
-    get :for, "apps/{app_id}/events{?query*}", optional: [:query]
+    get :list, "events{?query*}", optional: [:app_id, :query] do |req, params|
+      # Can't rely on URI templates if we need a static part depending on a dynamic one
+      req.path = "apps/#{params[:app_id]}/#{req.path}" if params[:app_id]
+    end
     get :types, "event_types"
     get :categories, "event_categories"
   end

--- a/lib/scalingo/regional/logs.rb
+++ b/lib/scalingo/regional/logs.rb
@@ -2,7 +2,7 @@ module Scalingo
   class Regional::Logs < API::Endpoint
     get :archives, "apps/{app_id}/logs_archives"
 
-    def get(url, **params, &block)
+    def fetch(url, **params, &block)
       request(:get, url, **params) do |req|
         block&.call(req, params)
         req.params[:n] = params[:n] if params[:n].present?
@@ -10,13 +10,13 @@ module Scalingo
     end
 
     ## Helper method to avoid having to manually chain two operations
-    def for(**params, &block)
+    def find(**params, &block)
       params[:id] = params.delete(:app_id) if params[:app_id].present?
       logs_response = client.apps.logs_url(**params)
 
       return logs_response unless logs_response.success?
 
-      get(logs_response.body, **params, &block)
+      fetch(logs_response.body, **params, &block)
     end
   end
 end

--- a/lib/scalingo/regional/metrics.rb
+++ b/lib/scalingo/regional/metrics.rb
@@ -4,7 +4,7 @@ require "active_support/core_ext/hash/indifferent_access"
 
 module Scalingo
   class Regional::Metrics < API::Endpoint
+    get :list, "/apps/{app_id}/stats/{metric}{/container_type}{/container_index}", optional: [:container_type, :container_index]
     get :types, "/features/metrics"
-    get :for, "/apps/{app_id}/stats/{metric}{/container_type}{/container_index}", optional: [:container_type, :container_index]
   end
 end

--- a/lib/scalingo/regional/notifiers.rb
+++ b/lib/scalingo/regional/notifiers.rb
@@ -2,12 +2,12 @@ require "scalingo/api/endpoint"
 
 module Scalingo
   class Regional::Notifiers < API::Endpoint
-    get :platforms, "/notification_platforms"
-    get :for, "/apps/{app_id}/notifiers"
+    get :list, "/apps/{app_id}/notifiers"
     get :find, "/apps/{app_id}/notifiers/{id}"
     post :create, "/apps/{app_id}/notifiers", root_key: :notifier
+    put :update, "/apps/{app_id}/notifiers/{id}", root_key: :notifier
+    delete :delete, "/apps/{app_id}/notifiers/{id}"
+    get :platforms, "/notification_platforms"
     post :test, "/apps/{app_id}/notifiers/{id}/test"
-    patch :update, "/apps/{app_id}/notifiers/{id}", root_key: :notifier
-    delete :destroy, "/apps/{app_id}/notifiers/{id}"
   end
 end

--- a/lib/scalingo/regional/operations.rb
+++ b/lib/scalingo/regional/operations.rb
@@ -4,7 +4,7 @@ module Scalingo
   class Regional::Operations < API::Endpoint
     get :find, "/apps/{app_id}/operations/{id}"
 
-    def get(url, **params, &block)
+    def fetch(url, **params, &block)
       request(:get, url, **params) do |req|
         block&.call(req, params)
       end

--- a/lib/scalingo/regional/scm_repo_links.rb
+++ b/lib/scalingo/regional/scm_repo_links.rb
@@ -2,13 +2,13 @@ require "scalingo/api/endpoint"
 
 module Scalingo
   class Regional::ScmRepoLinks < API::Endpoint
-    get :show, "/apps/{app_id}/scm_repo_link"
+    get :find, "/apps/{app_id}/scm_repo_link"
+    post :create, "/apps/{app_id}/scm_repo_link", root_key: :scm_repo_link
+    put :update, "/apps/{app_id}/scm_repo_link", root_key: :scm_repo_link
+    delete :delete, "/apps/{app_id}/scm_repo_link"
     get :branches, "/apps/{app_id}/scm_repo_link/branches"
     get :pulls, "/apps/{app_id}/scm_repo_link/pulls"
-    post :create, "/apps/{app_id}/scm_repo_link", root_key: :scm_repo_link
     post :deploy, "/apps/{app_id}/scm_repo_link/manual_deploy"
     post :review_app, "/apps/{app_id}/scm_repo_link/manual_review_app"
-    patch :update, "/apps/{app_id}/scm_repo_link", root_key: :scm_repo_link
-    delete :destroy, "/apps/{app_id}/scm_repo_link"
   end
 end

--- a/lib/scalingo/regional_database/backups.rb
+++ b/lib/scalingo/regional_database/backups.rb
@@ -2,8 +2,8 @@ require "scalingo/api/endpoint"
 
 module Scalingo
   class RegionalDatabase::Backups < API::Endpoint
-    get :for, "databases/{addon_id}/backups"
-    get :archive, "databases/{addon_id}/backups/{id}/archive"
+    get :list, "databases/{addon_id}/backups"
     post :create, "databases/{addon_id}/backups"
+    get :archive, "databases/{addon_id}/backups/{id}/archive"
   end
 end

--- a/spec/scalingo/auth/keys_spec.rb
+++ b/spec/scalingo/auth/keys_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 
 RSpec.describe Scalingo::Auth::Keys, type: :endpoint do
-  describe "all" do
-    subject(:response) { instance.all(**arguments) }
+  describe "list" do
+    subject(:response) { instance.list(**arguments) }
 
     include_examples "requires authentication"
 
@@ -19,8 +19,8 @@ RSpec.describe Scalingo::Auth::Keys, type: :endpoint do
     it { is_expected.to have_requested(:post, api_path.merge("/keys")).with(body: {key: body}) }
   end
 
-  describe "show" do
-    subject(:response) { instance.show(**arguments) }
+  describe "find" do
+    subject(:response) { instance.find(**arguments) }
 
     let(:params) { {id: "key-id"} }
 
@@ -30,8 +30,8 @@ RSpec.describe Scalingo::Auth::Keys, type: :endpoint do
     it { is_expected.to have_requested(:get, api_path.merge("/keys/key-id")) }
   end
 
-  describe "destroy" do
-    subject(:response) { instance.destroy(**arguments) }
+  describe "delete" do
+    subject(:response) { instance.delete(**arguments) }
 
     let(:params) { {id: "key-id"} }
 

--- a/spec/scalingo/auth/scm_integrations_spec.rb
+++ b/spec/scalingo/auth/scm_integrations_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 
 RSpec.describe Scalingo::Auth::ScmIntegrations, type: :endpoint do
-  describe "all" do
-    subject(:response) { instance.all(**arguments) }
+  describe "list" do
+    subject(:response) { instance.list(**arguments) }
 
     include_examples "requires authentication"
 
@@ -19,8 +19,8 @@ RSpec.describe Scalingo::Auth::ScmIntegrations, type: :endpoint do
     it { is_expected.to have_requested(:post, api_path.merge("/scm_integrations")).with(body: {scm_integration: body}) }
   end
 
-  describe "show" do
-    subject(:response) { instance.show(**arguments) }
+  describe "find" do
+    subject(:response) { instance.find(**arguments) }
 
     let(:params) { {id: "scm-integration-id"} }
 
@@ -30,8 +30,8 @@ RSpec.describe Scalingo::Auth::ScmIntegrations, type: :endpoint do
     it { is_expected.to have_requested(:get, api_path.merge("/scm_integrations/scm-integration-id")) }
   end
 
-  describe "destroy" do
-    subject(:response) { instance.destroy(**arguments) }
+  describe "delete" do
+    subject(:response) { instance.delete(**arguments) }
 
     let(:params) { {id: "scm-integration-id"} }
 

--- a/spec/scalingo/auth/tokens_spec.rb
+++ b/spec/scalingo/auth/tokens_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 
 RSpec.describe Scalingo::Auth::Tokens, type: :endpoint do
-  describe "all" do
-    subject(:response) { instance.all(**arguments) }
+  describe "list" do
+    subject(:response) { instance.list(**arguments) }
 
     include_examples "requires authentication"
 
@@ -38,11 +38,11 @@ RSpec.describe Scalingo::Auth::Tokens, type: :endpoint do
     include_examples "requires authentication"
     include_examples "requires some params", :id
 
-    it { is_expected.to have_requested(:patch, api_path.merge("/tokens/token-id/renew")) }
+    it { is_expected.to have_requested(:put, api_path.merge("/tokens/token-id/renew")) }
   end
 
-  describe "destroy" do
-    subject(:response) { instance.destroy(**arguments) }
+  describe "delete" do
+    subject(:response) { instance.delete(**arguments) }
 
     let(:params) { {id: "token-id"} }
 

--- a/spec/scalingo/auth/user_spec.rb
+++ b/spec/scalingo/auth/user_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 
 RSpec.describe Scalingo::Auth::User, type: :endpoint do
-  describe "self" do
-    subject(:response) { instance.self(**arguments) }
+  describe "find" do
+    subject(:response) { instance.find(**arguments) }
 
     include_examples "requires authentication"
 

--- a/spec/scalingo/billing/profile_spec.rb
+++ b/spec/scalingo/billing/profile_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Scalingo::Billing::Profile, type: :endpoint do
     it { is_expected.to have_requested(:get, api_path.merge("/profile")) }
   end
 
-  describe "self" do
-    subject(:response) { instance.self(**arguments) }
+  describe "find" do
+    subject(:response) { instance.find(**arguments) }
 
     include_examples "requires authentication"
 

--- a/spec/scalingo/billing/profile_spec.rb
+++ b/spec/scalingo/billing/profile_spec.rb
@@ -11,14 +11,6 @@ RSpec.describe Scalingo::Billing::Profile, type: :endpoint do
     it { is_expected.to have_requested(:post, api_path.merge("/profiles")).with(body: {profile: body}) }
   end
 
-  describe "show" do
-    subject(:response) { instance.show(**arguments) }
-
-    include_examples "requires authentication"
-
-    it { is_expected.to have_requested(:get, api_path.merge("/profile")) }
-  end
-
   describe "find" do
     subject(:response) { instance.find(**arguments) }
 

--- a/spec/scalingo/client_spec.rb
+++ b/spec/scalingo/client_spec.rb
@@ -90,4 +90,11 @@ RSpec.describe Scalingo::Client do
       end
     end
   end
+
+  describe "self" do
+    it "returns the authenticated user" do
+      expect(subject.auth.user).to receive(:find).and_return(:user)
+      expect(subject.self).to eq :user
+    end
+  end
 end

--- a/spec/scalingo/regional/addons_spec.rb
+++ b/spec/scalingo/regional/addons_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Scalingo::Regional::Addons, type: :endpoint do
     it { is_expected.to have_requested(:get, api_path.merge("/addon_categories")) }
   end
 
-  describe "for" do
-    subject(:response) { instance.for(**arguments) }
+  describe "list" do
+    subject(:response) { instance.list(**arguments) }
 
     let(:params) { {app_id: app_id} }
 
@@ -26,8 +26,8 @@ RSpec.describe Scalingo::Regional::Addons, type: :endpoint do
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/addons")) }
   end
 
-  describe "provision" do
-    subject(:response) { instance.provision(**arguments) }
+  describe "create" do
+    subject(:response) { instance.create(**arguments) }
 
     let(:params) { {app_id: app_id} }
     let(:body) { {field: "value"} }
@@ -58,7 +58,7 @@ RSpec.describe Scalingo::Regional::Addons, type: :endpoint do
     include_examples "requires authentication"
     include_examples "requires some params", :app_id, :id
 
-    it { is_expected.to have_requested(:patch, api_path.merge("/apps/my-app-id/addons/addon-id")).with(body: {addon: body}) }
+    it { is_expected.to have_requested(:put, api_path.merge("/apps/my-app-id/addons/addon-id")).with(body: {addon: body}) }
   end
 
   describe "sso" do
@@ -83,8 +83,8 @@ RSpec.describe Scalingo::Regional::Addons, type: :endpoint do
     it { is_expected.to have_requested(:post, api_path.merge("/apps/my-app-id/addons/addon-id/token")) }
   end
 
-  describe "destroy" do
-    subject(:response) { instance.destroy(**arguments) }
+  describe "delete" do
+    subject(:response) { instance.delete(**arguments) }
 
     let(:params) { {app_id: app_id, id: "addon-id"} }
 

--- a/spec/scalingo/regional/apps_spec.rb
+++ b/spec/scalingo/regional/apps_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 
 RSpec.describe Scalingo::Regional::Apps, type: :endpoint do
-  describe "all" do
-    subject(:response) { instance.all(**arguments) }
+  describe "list" do
+    subject(:response) { instance.list(**arguments) }
 
     include_examples "requires authentication"
 
@@ -56,7 +56,7 @@ RSpec.describe Scalingo::Regional::Apps, type: :endpoint do
     include_examples "requires authentication"
     include_examples "requires some params", :id
 
-    it { is_expected.to have_requested(:patch, api_path.merge("/apps/my-app-id")).with(body: {app: body}) }
+    it { is_expected.to have_requested(:put, api_path.merge("/apps/my-app-id")).with(body: {app: body}) }
   end
 
   describe "rename" do
@@ -80,11 +80,11 @@ RSpec.describe Scalingo::Regional::Apps, type: :endpoint do
     include_examples "requires authentication"
     include_examples "requires some params", :id
 
-    it { is_expected.to have_requested(:patch, api_path.merge("/apps/my-app-id")).with(body: body) }
+    it { is_expected.to have_requested(:put, api_path.merge("/apps/my-app-id")).with(body: body) }
   end
 
-  describe "destroy" do
-    subject(:response) { instance.destroy(**arguments) }
+  describe "delete" do
+    subject(:response) { instance.delete(**arguments) }
 
     let(:params) { {id: "my-app-id"} }
 

--- a/spec/scalingo/regional/autoscalers_spec.rb
+++ b/spec/scalingo/regional/autoscalers_spec.rb
@@ -3,8 +3,8 @@ require "spec_helper"
 RSpec.describe Scalingo::Regional::Autoscalers, type: :endpoint do
   let(:app_id) { "my-app-id" }
 
-  describe "for" do
-    subject(:response) { instance.for(**arguments) }
+  describe "list" do
+    subject(:response) { instance.list(**arguments) }
 
     let(:params) { {app_id: app_id} }
 
@@ -46,11 +46,11 @@ RSpec.describe Scalingo::Regional::Autoscalers, type: :endpoint do
     include_examples "requires authentication"
     include_examples "requires some params", :app_id, :id
 
-    it { is_expected.to have_requested(:patch, api_path.merge("/apps/my-app-id/autoscalers/autoscaler-id")).with(body: {autoscaler: body}) }
+    it { is_expected.to have_requested(:put, api_path.merge("/apps/my-app-id/autoscalers/autoscaler-id")).with(body: {autoscaler: body}) }
   end
 
-  describe "destroy" do
-    subject(:response) { instance.destroy(**arguments) }
+  describe "delete" do
+    subject(:response) { instance.delete(**arguments) }
 
     let(:params) { {app_id: app_id, id: "autoscaler-id"} }
 

--- a/spec/scalingo/regional/collaborators_spec.rb
+++ b/spec/scalingo/regional/collaborators_spec.rb
@@ -3,8 +3,8 @@ require "spec_helper"
 RSpec.describe Scalingo::Regional::Collaborators, type: :endpoint do
   let(:app_id) { "my-app-id" }
 
-  describe "for" do
-    subject(:response) { instance.for(**arguments) }
+  describe "list" do
+    subject(:response) { instance.list(**arguments) }
 
     let(:params) { {app_id: app_id} }
 
@@ -25,8 +25,8 @@ RSpec.describe Scalingo::Regional::Collaborators, type: :endpoint do
     it { is_expected.to have_requested(:get, api_path.merge("/apps/collaboration?token=some-token")) }
   end
 
-  describe "invite" do
-    subject(:response) { instance.invite(**arguments) }
+  describe "create" do
+    subject(:response) { instance.create(**arguments) }
 
     let(:params) { {app_id: app_id} }
     let(:body) { {field: "value"} }
@@ -37,8 +37,8 @@ RSpec.describe Scalingo::Regional::Collaborators, type: :endpoint do
     it { is_expected.to have_requested(:post, api_path.merge("/apps/my-app-id/collaborators")).with(body: {collaborator: body}) }
   end
 
-  describe "destroy" do
-    subject(:response) { instance.destroy(**arguments) }
+  describe "delete" do
+    subject(:response) { instance.delete(**arguments) }
 
     let(:params) { {app_id: app_id, id: "collaborator-id"} }
 

--- a/spec/scalingo/regional/containers_spec.rb
+++ b/spec/scalingo/regional/containers_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Scalingo::Regional::Containers, type: :endpoint do
     it { is_expected.to have_requested(:get, api_path.merge("/features/container_sizes")) }
   end
 
-  describe "for" do
-    subject(:response) { instance.for(**arguments) }
+  describe "list" do
+    subject(:response) { instance.list(**arguments) }
 
     let(:params) { {app_id: app_id} }
 

--- a/spec/scalingo/regional/deployments_spec.rb
+++ b/spec/scalingo/regional/deployments_spec.rb
@@ -3,8 +3,8 @@ require "spec_helper"
 RSpec.describe Scalingo::Regional::Deployments, type: :endpoint do
   let(:app_id) { "my-app-id" }
 
-  describe "for" do
-    subject(:response) { instance.for(**arguments) }
+  describe "list" do
+    subject(:response) { instance.list(**arguments) }
 
     let(:params) { {app_id: app_id} }
 

--- a/spec/scalingo/regional/domains_spec.rb
+++ b/spec/scalingo/regional/domains_spec.rb
@@ -3,8 +3,8 @@ require "spec_helper"
 RSpec.describe Scalingo::Regional::Domains, type: :endpoint do
   let(:app_id) { "my-app-id" }
 
-  describe "for" do
-    subject(:response) { instance.for(**arguments) }
+  describe "list" do
+    subject(:response) { instance.list(**arguments) }
 
     let(:params) { {app_id: app_id} }
 
@@ -46,11 +46,11 @@ RSpec.describe Scalingo::Regional::Domains, type: :endpoint do
     include_examples "requires authentication"
     include_examples "requires some params", :app_id, :id
 
-    it { is_expected.to have_requested(:patch, api_path.merge("/apps/my-app-id/domains/domain-id")).with(body: {domain: body}) }
+    it { is_expected.to have_requested(:put, api_path.merge("/apps/my-app-id/domains/domain-id")).with(body: {domain: body}) }
   end
 
-  describe "destroy" do
-    subject(:response) { instance.destroy(**arguments) }
+  describe "delete" do
+    subject(:response) { instance.delete(**arguments) }
 
     let(:params) { {app_id: app_id, id: "domain-id"} }
 

--- a/spec/scalingo/regional/environment_spec.rb
+++ b/spec/scalingo/regional/environment_spec.rb
@@ -3,8 +3,8 @@ require "spec_helper"
 RSpec.describe Scalingo::Regional::Environment, type: :endpoint do
   let(:app_id) { "my-app-id" }
 
-  describe "for" do
-    subject(:response) { instance.for(**arguments) }
+  describe "list" do
+    subject(:response) { instance.list(**arguments) }
 
     let(:params) { {app_id: app_id} }
 
@@ -35,7 +35,7 @@ RSpec.describe Scalingo::Regional::Environment, type: :endpoint do
     include_examples "requires authentication"
     include_examples "requires some params", :app_id, :id
 
-    it { is_expected.to have_requested(:patch, api_path.merge("/apps/my-app-id/variables/variable-id")).with(body: {variable: body}) }
+    it { is_expected.to have_requested(:put, api_path.merge("/apps/my-app-id/variables/variable-id")).with(body: {variable: body}) }
   end
 
   describe "bulk_update" do
@@ -50,8 +50,8 @@ RSpec.describe Scalingo::Regional::Environment, type: :endpoint do
     it { is_expected.to have_requested(:put, api_path.merge("/apps/my-app-id/variables")).with(body: {variables: body}) }
   end
 
-  describe "destroy" do
-    subject(:response) { instance.destroy(**arguments) }
+  describe "delete" do
+    subject(:response) { instance.delete(**arguments) }
 
     let(:params) { {app_id: app_id, id: "variable-id"} }
 

--- a/spec/scalingo/regional/events_spec.rb
+++ b/spec/scalingo/regional/events_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Scalingo::Regional::Events, type: :endpoint do
     it { is_expected.to have_requested(:get, api_path.merge("/event_categories")) }
   end
 
-  describe "all" do
-    subject(:response) { instance.all(**arguments) }
+  describe "list" do
+    subject(:response) { instance.list(**arguments) }
 
     include_examples "requires authentication"
 
@@ -25,23 +25,18 @@ RSpec.describe Scalingo::Regional::Events, type: :endpoint do
 
       it { is_expected.to have_requested(:get, api_path.merge("/events?page=2")) }
     end
-  end
 
-  describe "for" do
-    subject(:response) { instance.for(**arguments) }
+    context "with app_id" do
+      let(:app_id) { "my-app-id" }
+      let(:params) { {app_id: app_id} }
 
-    let(:app_id) { "my-app-id" }
-    let(:params) { {app_id: app_id} }
+      it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/events")) }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+      context "with query string" do
+        let(:params) { {app_id: app_id, query: {page: 2}} }
 
-    it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/events")) }
-
-    context "with query string" do
-      let(:params) { {app_id: app_id, query: {page: 2}} }
-
-      it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/events?page=2")) }
+        it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/events?page=2")) }
+      end
     end
   end
 end

--- a/spec/scalingo/regional/logs_spec.rb
+++ b/spec/scalingo/regional/logs_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Scalingo::Regional::Logs, type: :endpoint do
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/logs_archives")) }
   end
 
-  describe "get" do
-    subject(:response) { instance.get("http://localhost/any-url", **arguments) }
+  describe "fetch" do
+    subject(:response) { instance.fetch("http://localhost/any-url", **arguments) }
 
     include_examples "requires authentication"
 
@@ -34,8 +34,8 @@ RSpec.describe Scalingo::Regional::Logs, type: :endpoint do
     end
   end
 
-  describe "for" do
-    subject(:response) { instance.for(**arguments) }
+  describe "find" do
+    subject(:response) { instance.find(**arguments) }
 
     let(:params) { {app_id: app_id} }
 

--- a/spec/scalingo/regional/metrics_spec.rb
+++ b/spec/scalingo/regional/metrics_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Scalingo::Regional::Metrics, type: :endpoint do
     it { is_expected.to have_requested(:get, api_path.merge("/features/metrics")) }
   end
 
-  describe "for" do
-    subject(:response) { instance.for(**arguments) }
+  describe "list" do
+    subject(:response) { instance.list(**arguments) }
 
     let(:params) { {app_id: app_id, metric: "some-metric"} }
 

--- a/spec/scalingo/regional/notifiers_spec.rb
+++ b/spec/scalingo/regional/notifiers_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Scalingo::Regional::Notifiers, type: :endpoint do
     it { is_expected.to have_requested(:get, api_path.merge("/notification_platforms")) }
   end
 
-  describe "for" do
-    subject(:response) { instance.for(**arguments) }
+  describe "list" do
+    subject(:response) { instance.list(**arguments) }
 
     let(:params) { {app_id: app_id} }
 
@@ -52,7 +52,7 @@ RSpec.describe Scalingo::Regional::Notifiers, type: :endpoint do
     include_examples "requires authentication"
     include_examples "requires some params", :app_id, :id
 
-    it { is_expected.to have_requested(:patch, api_path.merge("/apps/my-app-id/notifiers/notifier-id")).with(body: {notifier: body}) }
+    it { is_expected.to have_requested(:put, api_path.merge("/apps/my-app-id/notifiers/notifier-id")).with(body: {notifier: body}) }
   end
 
   describe "test" do
@@ -66,8 +66,8 @@ RSpec.describe Scalingo::Regional::Notifiers, type: :endpoint do
     it { is_expected.to have_requested(:post, api_path.merge("/apps/my-app-id/notifiers/notifier-id/test")) }
   end
 
-  describe "destroy" do
-    subject(:response) { instance.destroy(**arguments) }
+  describe "delete" do
+    subject(:response) { instance.delete(**arguments) }
 
     let(:params) { {app_id: app_id, id: "notifier-id"} }
 

--- a/spec/scalingo/regional/operations_spec.rb
+++ b/spec/scalingo/regional/operations_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Scalingo::Regional::Operations, type: :endpoint do
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/operations/op-id")) }
   end
 
-  describe "get" do
-    subject(:response) { instance.get("http://localhost/any-url") }
+  describe "fetch" do
+    subject(:response) { instance.fetch("http://localhost/any-url") }
 
     include_examples "requires authentication"
 

--- a/spec/scalingo/regional/scm_repo_links_spec.rb
+++ b/spec/scalingo/regional/scm_repo_links_spec.rb
@@ -3,8 +3,8 @@ require "spec_helper"
 RSpec.describe Scalingo::Regional::ScmRepoLinks, type: :endpoint do
   let(:app_id) { "my-app-id" }
 
-  describe "show" do
-    subject(:response) { instance.show(**arguments) }
+  describe "find" do
+    subject(:response) { instance.find(**arguments) }
 
     let(:params) { {app_id: app_id} }
 
@@ -81,11 +81,11 @@ RSpec.describe Scalingo::Regional::ScmRepoLinks, type: :endpoint do
     include_examples "requires authentication"
     include_examples "requires some params", :app_id
 
-    it { is_expected.to have_requested(:patch, api_path.merge("/apps/my-app-id/scm_repo_link")).with(body: {scm_repo_link: body}) }
+    it { is_expected.to have_requested(:put, api_path.merge("/apps/my-app-id/scm_repo_link")).with(body: {scm_repo_link: body}) }
   end
 
-  describe "destroy" do
-    subject(:response) { instance.destroy(**arguments) }
+  describe "delete" do
+    subject(:response) { instance.delete(**arguments) }
 
     let(:params) { {app_id: app_id} }
 

--- a/spec/scalingo/regional_database/backups_spec.rb
+++ b/spec/scalingo/regional_database/backups_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Scalingo::RegionalDatabase::Backups, type: :endpoint do
     scalingo_client.add_database_token(addon_id, "the-bearer-token")
   end
 
-  describe "for" do
-    subject(:response) { instance.for(**arguments) }
+  describe "list" do
+    subject(:response) { instance.list(**arguments) }
 
     let(:params) { {addon_id: addon_id} }
 


### PR DESCRIPTION
Introduce helper scripts, then rename methods to use consistent names:

* `list` for fetching a collection of resources. Example: `keys.list`
* `find` for fetching a singular resource. Example: `keys.find(id: 'key')`
* `create` for creating a resource. Example: `keys.create(name: 'key')`
* `update` for updating a resource. Example: `keys.update(id: 'key', name: 'new-key')`
* `delete` for deleting a resource. Example: `keys.delete(id: 'key')`

(this will end up in the readme, yep)

Related resources (eg: `containers.sizes`, `addons.categories`, `repo_link.branches`) stay the same for now, but they might be renamed/moved around too later.

Specs are adapted. Some aliases are removed, and there's a specific case for events for which URI templates are not well adapted: if there's an app_id supplied, we need to prefix it with `/apps`, but adding a static part if a variable is expanded doesn't seem to be possible.