### PR TITLE
Always raise on errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 4.0.beta1 - 2024-04-15
 
 * Breaking change: exceptions are raised on error responses (4xx, 5xx) and other errors (connection issue, timeouts)
     * Trying to reach an endpoint without having the client authenticated will raise an exception without attempting the request

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+* Breaking change: exceptions are raised on error responses (4xx, 5xx) and other errors (connection issue, timeouts)
+    * Trying to reach an endpoint without having the client authenticated will raise an exception without attempting the request
+    * Same when the token is expired. Expiration date is read from the token directly
+    * Associated configuration options have been removed
 * Breaking change: rework DB api exposition
 * Specs: rewrite all specs
 * Breaking change: endpoint methods declaration is simplified:

--- a/README.md
+++ b/README.md
@@ -2,13 +2,10 @@
 
 A ruby wrapper for the Scalingo API
 
-> [!WARNING]
-> `master` is under development and contains yet-to-be-documented breaking changes. The readme is about the stable v3 interface.
-
 ## Installation
 
 ```ruby
-gem "scalingo", "3.0.0"
+gem "scalingo"
 ```
 
 And then execute:
@@ -24,7 +21,7 @@ require "scalingo"
 
 scalingo = Scalingo::Client.new
 scalingo.authenticate_with(access_token: ENV["SCALINGO_TOKEN"])
-scalingo.user.self
+scalingo.self
 ```
 
 ## Conventions
@@ -32,16 +29,13 @@ scalingo.user.self
 Most methods map to one (and only one) request, and their signature follows this format:
 
 ```ruby
-client.section.request(id, payload = {}, headers = nil, &block)
+client.section.request(app_id:, id:, body:)
 ```
 
 * Depending on the request, there may be no id (collection and/or singular resource, such as `user`), one, or two ids (many resources are nested under an app).
 * Most of the time, this library won't do any processing of the payload, but there's a few things to know:
-  * the root key shouldn't be specified, the library handles it
+  * the root key doesn't need to be specified, the library handles it
   * in some cases, the payload isn't passed as supplied (`metrics`, for instance, extracts the parts that are meant to be used as url fragments)
-* headers can be supplied on a per-request basis, using either the last argument or the block version:
-  * when using the last argument, you may have to pass an empty hash payload (`{}`)
-  * when using the block form, the faraday object is supplied as argument, and you can do any kind of treatment you would like
 
 ## Configuration
 
@@ -53,23 +47,13 @@ changing the configuration globally will therefore not affect already existing o
 
 ```ruby
 Scalingo.configure do |config|
-  # Default region. Must be a supported region (agora_fr1, osc_fr1, osc_secnum_fr1)
+  # Default region. Must be a supported region (osc_fr1, osc_secnum_fr1)
   config.default_region = :osc_fr1
 
   # Configure the User Agent header
   config.user_agent = "Scalingo Ruby Client v#{Scalingo::VERSION}"
 
-  # For how long is a bearer token considered valid (it will raise passed this delay).
-  # Set to nil to never raise.
-  config.exchanged_token_validity = 1.hour
-
-  # Having this setting to true prevents performing requests that would fail due to lack of authentication headers.
-  config.raise_on_missing_authentication = true
-
-  # Raise an exception when the bearer token in use is supposed to be invalid
-  config.raise_on_expired_token = false
-
-  # These headers will be added to every request. Individual methods may override them.
+  # These headers will be added to every request
   # This should be a hash or a callable object that returns a hash.
   config.additional_headers = {}
 
@@ -82,25 +66,8 @@ You can also configure each client separately.
 Values not supplied will be copied from the global configuration.
 
 ```ruby
-scalingo = Scalingo::Client.new(raise_on_expired_token: false)
+scalingo = Scalingo::Client.new(user_agent: "A new kind of agent")
 ```
-
-## Response object
-
-Responses are parsed with the keys symbolized and then encapsulated in a `Scalingo::API::Response` object:
-
-* `response.status` containts the HTTP status code
-* `response.data` contains the "relevant" data, without the json root key (when relevant)
-* `response.full_body` contains the full response body
-* `response.meta` contains the meta object, if there's any
-* `response.headers` containts all the response headers
-
-Some helper methods are defined on this object:
-* `response.successful?` returns true when the code is 2XX
-* `response.paginated?` returns true if the reponse has metadata relative to pagination
-* `response.operation?` returns true if the response contains a header relative to an ongoing operation
-* `response.operation_url` returns the URL to query to get the status of the operation
-* `response.operation` performs a request to retrieve the operation
 
 ## Other details on the code architecture
 
@@ -122,13 +89,13 @@ scalingo.authenticate_with(access_token: "my_access_token")
 scalingo.authenticate_with(bearer_token: "my_bearer_jwt")
 
 # Return your profile
-scalingo.user.self
+scalingo.self # or scalingo.auth.user.find
 
 # List your SSH Keys
 scalingo.keys.all # OR scalingo.auth.keys.all
 
 # Show one SSH Key
-scalingo.keys.show("my-key-id")
+scalingo.keys.show(id: "my-key-id")
 
 # List your apps on the default region
 scalingo.apps.all # OR scalingo.region.apps.all
@@ -146,8 +113,6 @@ Requests to the [database API](https://developers.scalingo.com/databases/) requi
 extra authentication for each addon you want to interact with. [Addon authentication
 tokens are valid for one hour](https://developers.scalingo.com/addons#get-addon-token).
 
-Supported regions for database API are `db_api_osc_fr1` and `db_api_osc_secnum_fr1`.
-
 ```ruby
 require "scalingo"
 
@@ -155,23 +120,20 @@ scalingo = Scalingo::Client.new
 scalingo.authenticate_with(access_token: "my_access_token")
 
 # First, authenticate using the `addons` API
-scalingo.osc_fr1.addons.authenticate!(app_id, addon_id)
+dbclient = scalingo.osc_fr1.addons.database_client_for(app_id:, id:)
 
 # Once authenticated for that specific addon, you can interact with
 # database and backup APIs.
 # IDs of databases are the IDs of the corresponding addons
 
 # get all information for a given database
-scalingo.db_api_osc_fr1.databases.find(addon_id)
+dbclient.databases.find(id:)
 
 # get all backups for a given database
-scalingo.db_api_osc_fr1.backups.for(addon_id)
+dbclient.backups.list(addon_id:)
 
 # get URL to download backup archive
-scalingo.db_api_osc_fr1.backups.archive(addon_id, backup_id)
-
-# you can omit the region to use the default one
-scalingo.databases.find(addon_id)
+dbclient.backups.archive(addon_id:, id:)
 
 ```
 
@@ -187,10 +149,4 @@ bundle
 
 ```bash
 bundle exec rspec
-```
-
-### Release a new version
-
-```bash
-# TODO
 ```

--- a/lib/scalingo/api/client.rb
+++ b/lib/scalingo/api/client.rb
@@ -82,6 +82,7 @@ module Scalingo
           conn.response :extract_root_value
           conn.response :extract_meta
           conn.response :json, content_type: /\bjson$/, parser_options: {symbolize_names: true}
+          conn.response :raise_error
           conn.request :json
 
           conn.adapter(config.faraday_adapter) if config.faraday_adapter
@@ -99,6 +100,7 @@ module Scalingo
           conn.response :extract_meta
           conn.response :json, content_type: /\bjson$/, parser_options: {symbolize_names: true}
           conn.request :json
+          conn.response :raise_error
           conn.request :authorization, "Bearer", -> { token_holder.token&.value }
 
           conn.adapter(config.faraday_adapter) if config.faraday_adapter

--- a/lib/scalingo/api/endpoint.rb
+++ b/lib/scalingo/api/endpoint.rb
@@ -79,7 +79,7 @@ module Scalingo
         request_body = {root_key => body} if request_body && root_key
 
         # We can use the client in either connected or unconnected mode
-        conn = connected ? client.authenticated_connection : client.unauthenticated_connection
+        conn = connected ? client.connection : client.guest_connection
 
         # We can specify basic auth credentials if needed
         conn.request :authorization, :basic, basic[:user], basic[:password] if basic.present?

--- a/lib/scalingo/bearer_token.rb
+++ b/lib/scalingo/bearer_token.rb
@@ -3,11 +3,9 @@ require "jwt"
 module Scalingo
   class BearerToken
     attr_reader :expires_at
-    attr_writer :raise_on_expired
 
-    def initialize(value, raise_on_expired: false)
+    def initialize(value)
       @value = value
-      @raise_on_expired = raise_on_expired
 
       read_expiration!
     end
@@ -29,16 +27,12 @@ module Scalingo
     end
     # :nocov:
 
-    def raise_on_expired?
-      @raise_on_expired
-    end
-
     def expired?
       expires_at && expires_at <= Time.now
     end
 
     def value
-      raise Error::ExpiredToken if expired? && raise_on_expired?
+      raise Error::ExpiredToken if expired?
 
       @value
     end

--- a/lib/scalingo/bearer_token.rb
+++ b/lib/scalingo/bearer_token.rb
@@ -1,12 +1,15 @@
+require "jwt"
+
 module Scalingo
   class BearerToken
     attr_reader :expires_at
     attr_writer :raise_on_expired
 
-    def initialize(value, expires_at: nil, raise_on_expired: false)
+    def initialize(value, raise_on_expired: false)
       @value = value
-      @expires_at = expires_at if expires_at
       @raise_on_expired = raise_on_expired
+
+      read_expiration!
     end
 
     # :nocov:
@@ -38,6 +41,14 @@ module Scalingo
       raise Error::ExpiredToken if expired? && raise_on_expired?
 
       @value
+    end
+
+    private
+
+    def read_expiration!
+      payload, _ = JWT.decode(@value, nil, false)
+
+      @expires_at = Time.at(payload["exp"]) if payload["exp"]
     end
   end
 end

--- a/lib/scalingo/configuration.rb
+++ b/lib/scalingo/configuration.rb
@@ -15,10 +15,6 @@ module Scalingo
       # Set to nil to never raise.
       :exchanged_token_validity,
 
-      # Raise an exception when trying to use an authenticated connection without a bearer token set
-      # Having this setting to true prevents performing requests that would fail due to lack of authentication headers.
-      :raise_on_missing_authentication,
-
       # Raise an exception when the bearer token in use is supposed to be invalid
       :raise_on_expired_token,
 
@@ -37,7 +33,6 @@ module Scalingo
         default_region: :osc_fr1,
         user_agent: "Scalingo Ruby Client v#{Scalingo::VERSION}",
         exchanged_token_validity: 1.hour,
-        raise_on_missing_authentication: true,
         raise_on_expired_token: false,
         additional_headers: {}
       )

--- a/lib/scalingo/configuration.rb
+++ b/lib/scalingo/configuration.rb
@@ -11,13 +11,6 @@ module Scalingo
       # Configure the User Agent header
       :user_agent,
 
-      # For how long is a bearer token considered valid (it will raise passed this delay).
-      # Set to nil to never raise.
-      :exchanged_token_validity,
-
-      # Raise an exception when the bearer token in use is supposed to be invalid
-      :raise_on_expired_token,
-
       # These headers will be added to every request. Individual methods may override them.
       # This should be a hash or a callable object that returns a hash.
       :additional_headers,
@@ -32,8 +25,6 @@ module Scalingo
       new(
         default_region: :osc_fr1,
         user_agent: "Scalingo Ruby Client v#{Scalingo::VERSION}",
-        exchanged_token_validity: 1.hour,
-        raise_on_expired_token: false,
         additional_headers: {}
       )
     end

--- a/lib/scalingo/configuration.rb
+++ b/lib/scalingo/configuration.rb
@@ -1,20 +1,10 @@
 require "active_support"
 require "active_support/core_ext/numeric/time"
 require "scalingo/version"
-require "ostruct"
 
 module Scalingo
   class Configuration
     ATTRIBUTES = [
-      # URL to the authentication API
-      # :auth,
-
-      # URL to the billing API
-      # :billing,
-
-      # List of regions under the form {"region_id": root_url}
-      # :regions,
-
       # Default region. Must match a key in `regions`
       :default_region,
 

--- a/lib/scalingo/core_client.rb
+++ b/lib/scalingo/core_client.rb
@@ -57,13 +57,11 @@ module Scalingo
       end
 
       if access_token
-        expiration = Time.now + config.exchanged_token_validity
         response = auth.tokens.exchange(basic: {password: access_token})
 
         if response.success?
           self.token = BearerToken.new(
             response.body,
-            expires_at: expiration,
             raise_on_expired: config.raise_on_expired_token
           )
         end

--- a/lib/scalingo/core_client.rb
+++ b/lib/scalingo/core_client.rb
@@ -43,7 +43,7 @@ module Scalingo
     end
 
     ## Authentication helpers / Token management
-    def authenticate_with(access_token: nil, bearer_token: nil, expires_at: nil)
+    def authenticate_with(access_token: nil, bearer_token: nil)
       if !access_token && !bearer_token
         raise ArgumentError, "You must supply one of `access_token` or `bearer_token`"
       end
@@ -52,29 +52,16 @@ module Scalingo
         raise ArgumentError, "You cannot supply both `access_token` and `bearer_token`"
       end
 
-      if expires_at && !bearer_token
-        raise ArgumentError, "`expires_at` can only be used with `bearer_token`. `access_token` have a 1 hour expiration."
-      end
-
       if access_token
         response = auth.tokens.exchange(basic: {password: access_token})
 
-        if response.success?
-          self.token = BearerToken.new(
-            response.body,
-            raise_on_expired: config.raise_on_expired_token
-          )
-        end
+        self.token = response.body if response.success?
 
         return response.success?
       end
 
       if bearer_token
-        authenticate_with_bearer_token(
-          bearer_token,
-          expires_at: expires_at,
-          raise_on_expired_token: config.raise_on_expired_token
-        )
+        self.token = bearer_token
 
         true
       end

--- a/lib/scalingo/faraday/response.rb
+++ b/lib/scalingo/faraday/response.rb
@@ -5,18 +5,6 @@ require "faraday/response"
 # we define additional methods for Faraday::Response in order to enhance expressiveness
 module Faraday
   class Response
-    def client_error?
-      RaiseError::ClientErrorStatuses.include?(status)
-    end
-
-    def server_error?
-      RaiseError::ServerErrorStatuses.include?(status)
-    end
-
-    def error?
-      !success?
-    end
-
     def meta
       env[:response_meta]
     end

--- a/lib/scalingo/regional/addons.rb
+++ b/lib/scalingo/regional/addons.rb
@@ -15,8 +15,6 @@ module Scalingo
     def database_client_for(app_id:, id:)
       response = token(app_id: app_id, id: id)
 
-      return nil unless response.status == 200
-
       db_url = Scalingo::Client::URLS.fetch(:database).fetch(client.region)
 
       db_client = Scalingo::Database.new(db_url, region: client.region)

--- a/lib/scalingo/regional/logs.rb
+++ b/lib/scalingo/regional/logs.rb
@@ -14,8 +14,6 @@ module Scalingo
       params[:id] = params.delete(:app_id) if params[:app_id].present?
       logs_response = client.apps.logs_url(**params)
 
-      return logs_response unless logs_response.success?
-
       fetch(logs_response.body, **params, &block)
     end
   end

--- a/lib/scalingo/token_holder.rb
+++ b/lib/scalingo/token_holder.rb
@@ -7,33 +7,11 @@ module Scalingo
     end
 
     def token=(input)
-      @token = bearer_token(input)
+      @token = input.is_a?(BearerToken) ? input : BearerToken.new(input.to_s)
     end
 
     def authenticated?
       token.present? && !token.expired?
-    end
-
-    def authenticate_with_bearer_token(bearer_token, expires_at:, raise_on_expired_token:)
-      self.token = build_bearer_token(bearer_token, expires_at: expires_at, raise_on_expired_token: raise_on_expired_token)
-    end
-
-    private
-
-    def bearer_token(token)
-      token.is_a?(BearerToken) ? token : BearerToken.new(token.to_s, raise_on_expired: config.raise_on_expired_token)
-    end
-
-    def build_bearer_token(bearer_token, expires_at:, raise_on_expired_token:)
-      return bearer_token unless expires_at
-
-      token = bearer_token.is_a?(BearerToken) ? bearer_token.value : bearer_token.to_s
-
-      BearerToken.new(
-        token,
-        expires_at: expires_at,
-        raise_on_expired: raise_on_expired_token
-      )
     end
   end
 end

--- a/lib/scalingo/version.rb
+++ b/lib/scalingo/version.rb
@@ -1,3 +1,3 @@
 module Scalingo
-  VERSION = "3.5.0"
+  VERSION = "4.0.beta1"
 end

--- a/scalingo.gemspec
+++ b/scalingo.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", [">= 5", "< 8"]
   s.add_dependency "faraday", "~> 2.0"
   s.add_dependency "multi_json", ">= 1.0.3", "~> 1.0"
+  s.add_dependency "jwt"
 
   s.add_development_dependency "bundler", "~> 2.0"
   s.add_development_dependency "dotenv"

--- a/scalingo.gemspec
+++ b/scalingo.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.executables = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.add_dependency "addressable", [">= 2.8.0", "< 3"]
   s.add_dependency "activesupport", [">= 5", "< 8"]
   s.add_dependency "faraday", "~> 2.0"
   s.add_dependency "multi_json", ">= 1.0.3", "~> 1.0"

--- a/spec/scalingo/api/client_spec.rb
+++ b/spec/scalingo/api/client_spec.rb
@@ -139,38 +139,27 @@ RSpec.describe Scalingo::API::Client do
     end
   end
 
-  describe "unauthenticated_connection" do
+  describe "guest_connection" do
     it "returns a memoized object" do
       expect(Faraday).to receive(:new).with(subject.connection_options).and_return("faraday").once
 
-      expect(subject.unauthenticated_connection).to eq "faraday"
+      expect(subject.guest_connection).to eq "faraday"
 
-      subject.unauthenticated_connection
-      subject.unauthenticated_connection
+      subject.guest_connection
+      subject.guest_connection
     end
 
     it "has no authentication header set" do
-      expect(subject.unauthenticated_connection.headers.key?("Authorization")).not_to be true
+      expect(subject.guest_connection.headers.key?("Authorization")).not_to be true
     end
   end
 
-  describe "authenticated_connection" do
+  describe "connection" do
     context "without bearer token" do
       let(:bearer_token) { nil }
 
-      it "raises if configured to" do
-        expect(scalingo.config).to receive(:raise_on_missing_authentication).and_return(true).once
-
-        expect {
-          subject.authenticated_connection
-        }.to raise_error(Scalingo::Error::Unauthenticated)
-      end
-
-      it "returns an unauthenticated connection if configured to not raise" do
-        expect(scalingo.config).to receive(:raise_on_missing_authentication).and_return(false).once
-
-        expect(subject).to receive(:unauthenticated_connection).and_return(:object).once
-        expect(subject.authenticated_connection).to eq(:object)
+      it "raises an exception" do
+        expect { subject.connection }.to raise_error(Scalingo::Error::Unauthenticated)
       end
     end
 
@@ -182,49 +171,6 @@ RSpec.describe Scalingo::API::Client do
         expected = "Bearer #{subject.token_holder.token.value}"
 
         expect(request_headers["Authorization"]).to eq(expected)
-      end
-    end
-  end
-
-  describe "connection" do
-    context "when logged" do
-      context "without fallback to guest" do
-        it "calls and return the authenticated_connection" do
-          expect(subject).to receive(:authenticated_connection).and_return(:conn)
-          expect(subject.connection).to eq(:conn)
-        end
-      end
-
-      context "with fallback to guest" do
-        it "calls and return the authenticated_connection" do
-          expect(subject).to receive(:authenticated_connection).and_return(:conn)
-          expect(subject.connection(fallback_to_guest: true)).to eq(:conn)
-        end
-      end
-    end
-
-    context "when not logged" do
-      let(:bearer_token) { nil }
-
-      context "without fallback to guest" do
-        it "raises when set to raise" do
-          expect(scalingo.config).to receive(:raise_on_missing_authentication).and_return(true).once
-
-          expect { subject.connection }.to raise_error(Scalingo::Error::Unauthenticated)
-        end
-
-        it "calls and return the unauthenticated_connection when set not to raise" do
-          expect(scalingo.config).to receive(:raise_on_missing_authentication).and_return(false).once
-          expect(subject).to receive(:unauthenticated_connection).and_return(:conn)
-          expect(subject.connection(fallback_to_guest: true)).to eq(:conn)
-        end
-      end
-
-      context "with fallback to guest" do
-        it "calls and return the unauthenticated_connection" do
-          expect(subject).to receive(:unauthenticated_connection).and_return(:conn)
-          expect(subject.connection(fallback_to_guest: true)).to eq(:conn)
-        end
       end
     end
   end

--- a/spec/scalingo/api/client_spec.rb
+++ b/spec/scalingo/api/client_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Scalingo::API::Client do
   subject { described_class.new(url, scalingo: scalingo) }
 
   let(:url) { "http://localhost" }
-  let(:bearer_token) { "bearer-token" }
+  let(:bearer_token) { Scalingo.generate_test_jwt(duration: 1.hour) }
   let(:configuration) { {} }
   let(:scalingo) do
     scalingo_client = Scalingo::Client.new(configuration)

--- a/spec/scalingo/bearer_token_spec.rb
+++ b/spec/scalingo/bearer_token_spec.rb
@@ -1,11 +1,10 @@
 require "spec_helper"
 
 RSpec.describe Scalingo::BearerToken do
-  subject { described_class.new(value, raise_on_expired: raise_on_expired) }
+  subject { described_class.new(value) }
 
   let(:duration) { 1.hour }
   let(:value) { Scalingo.generate_test_jwt(duration: duration) }
-  let(:raise_on_expired) { false }
 
   context "without duration" do
     let(:duration) { nil }
@@ -46,32 +45,14 @@ RSpec.describe Scalingo::BearerToken do
   end
 
   describe "value" do
-    context "when raising on expired token" do
-      let(:raise_on_expired) { true }
-
-      it "raises when expired" do
-        expect(subject).to receive(:expired?).and_return(true)
-        expect { subject.value }.to raise_error(Scalingo::Error::ExpiredToken)
-      end
-
-      it "returns the value when not expired" do
-        expect(subject).to receive(:expired?).and_return(false)
-        expect(subject.value).to eq(value)
-      end
+    it "raises when expired" do
+      expect(subject).to receive(:expired?).and_return(true)
+      expect { subject.value }.to raise_error(Scalingo::Error::ExpiredToken)
     end
 
-    context "when not raising on expired token" do
-      let(:raise_on_expired) { false }
-
-      it "returns the value when expired" do
-        expect(subject).to receive(:expired?).and_return(true)
-        expect(subject.value).to eq(value)
-      end
-
-      it "returns the value when not expired" do
-        expect(subject).to receive(:expired?).and_return(false)
-        expect(subject.value).to eq(value)
-      end
+    it "returns the value when not expired" do
+      expect(subject).to receive(:expired?).and_return(false)
+      expect(subject.value).to eq(value)
     end
   end
 end

--- a/spec/scalingo/bearer_token_spec.rb
+++ b/spec/scalingo/bearer_token_spec.rb
@@ -1,44 +1,47 @@
 require "spec_helper"
 
 RSpec.describe Scalingo::BearerToken do
-  subject { described_class.new(value, expires_at: expires_at, raise_on_expired: raise_on_expired) }
+  subject { described_class.new(value, raise_on_expired: raise_on_expired) }
 
-  let(:value) { "my-token" }
-  let(:expires_at) { nil }
+  let(:duration) { 1.hour }
+  let(:value) { Scalingo.generate_test_jwt(duration: duration) }
   let(:raise_on_expired) { false }
 
-  describe "initialize" do
-    it "stores the value" do
-      instance = described_class.new(:value)
+  context "without duration" do
+    let(:duration) { nil }
 
-      expect(instance.value).to eq(:value)
+    it "stores the value and no expiration" do
+      instance = described_class.new(value)
+
+      expect(instance.value).to eq(value)
       expect(instance.expires_at).to be_nil
     end
 
-    it "stores the expiration" do
-      expiration = Time.now + 1.hour
-      instance = described_class.new(:value, expires_at: expiration)
-
-      expect(instance.value).to eq(:value)
-      expect(instance.expires_at).to eq expiration
-    end
+    it { is_expected.not_to be_expired }
   end
 
-  describe "expired?" do
-    context "without expiration" do
-      it { expect(subject).not_to be_expired }
+  context "with duration" do
+    it "stores the value and the expiration" do
+      instance = described_class.new(value)
+
+      expect(instance.value).to eq(value)
+      expect(instance.expires_at).to be_within(3.seconds).of(Time.now + duration)
     end
 
-    context "with the expiration in the future" do
-      let(:expires_at) { Time.current + 1.hour }
+    it { is_expected.not_to be_expired }
 
-      it { expect(subject).not_to be_expired }
-    end
+    context "when the expiration date is in the past" do
+      it "is expired" do
+        subject # to initialize the subject
 
-    context "with the expiration in the past" do
-      let(:expires_at) { Time.current - 1.minute }
+        travel_to Time.now + duration - 1.minute do
+          expect(subject).not_to be_expired
+        end
 
-      it { expect(subject).to be_expired }
+        travel_to Time.now + duration + 1.minute do
+          expect(subject).to be_expired
+        end
+      end
     end
   end
 

--- a/spec/scalingo/configuration_spec.rb
+++ b/spec/scalingo/configuration_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe Scalingo::Configuration do
       let(:config) { {} }
 
       it "uses the default one when unspecificied" do
-        expect(client.authenticated_connection.adapter).to eq Faraday::Adapter::NetHttp
-        expect(client.unauthenticated_connection.adapter).to eq Faraday::Adapter::NetHttp
+        expect(client.connection.adapter).to eq Faraday::Adapter::NetHttp
+        expect(client.guest_connection.adapter).to eq Faraday::Adapter::NetHttp
       end
     end
 
@@ -40,8 +40,8 @@ RSpec.describe Scalingo::Configuration do
       let(:config) { {faraday_adapter: :yo} }
 
       it "uses the default one when unspecificied" do
-        expect { client.authenticated_connection.adapter }.to raise_error(Faraday::Error)
-        expect { client.unauthenticated_connection.adapter }.to raise_error(Faraday::Error)
+        expect { client.connection.adapter }.to raise_error(Faraday::Error)
+        expect { client.guest_connection.adapter }.to raise_error(Faraday::Error)
       end
     end
 
@@ -49,8 +49,8 @@ RSpec.describe Scalingo::Configuration do
       let(:config) { {faraday_adapter: :test} }
 
       it "uses the default one when unspecificied" do
-        expect(client.authenticated_connection.adapter).to eq Faraday::Adapter::Test
-        expect(client.unauthenticated_connection.adapter).to eq Faraday::Adapter::Test
+        expect(client.connection.adapter).to eq Faraday::Adapter::Test
+        expect(client.guest_connection.adapter).to eq Faraday::Adapter::Test
       end
     end
   end

--- a/spec/scalingo/configuration_spec.rb
+++ b/spec/scalingo/configuration_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe Scalingo::Configuration do
   end
 
   describe "faraday adapter" do
-    let(:scalingo) { Scalingo::Client.new(config).tap { |s| s.authenticate_with(bearer_token: "some-token") } }
+    let(:jwt) { Scalingo.generate_test_jwt(duration: 1.hour) }
+    let(:scalingo) { Scalingo::Client.new(config).tap { |s| s.authenticate_with(bearer_token: jwt) } }
     let(:client) { Scalingo::API::Client.new("http://example.test", scalingo: scalingo) }
 
     context "when unspecified" do

--- a/spec/scalingo/regional/addons_spec.rb
+++ b/spec/scalingo/regional/addons_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Scalingo::Regional::Addons, type: :endpoint do
 
         before do
           stub_request(:post, "http://localhost/apps/my-app-id/addons/addon-id/token").to_return(
-            body: {addon: {id: "addon-id", token: jwt}}.to_json,
+            body: {addon: {id: "addon-id", token: token}}.to_json,
             status: 200,
             headers: {content_type: "application/json"}
           )
@@ -103,7 +103,7 @@ RSpec.describe Scalingo::Regional::Addons, type: :endpoint do
         it "returns a database client" do
           expect(subject).to be_a(Scalingo::Database)
           expect(subject).to be_authenticated
-          expect(subject.token.value).to eq(jwt)
+          expect(subject.token.value).to eq(token)
         end
       end
 

--- a/spec/scalingo/regional/addons_spec.rb
+++ b/spec/scalingo/regional/addons_spec.rb
@@ -90,9 +90,11 @@ RSpec.describe Scalingo::Regional::Addons, type: :endpoint do
       end
 
       context "with a valid response" do
+        let(:token) { Scalingo.generate_test_jwt(duration: 1.hour) }
+
         before do
           stub_request(:post, "http://localhost/apps/my-app-id/addons/addon-id/token").to_return(
-            body: {addon: {id: "addon-id", token: "some-token"}}.to_json,
+            body: {addon: {id: "addon-id", token: jwt}}.to_json,
             status: 200,
             headers: {content_type: "application/json"}
           )
@@ -101,7 +103,7 @@ RSpec.describe Scalingo::Regional::Addons, type: :endpoint do
         it "returns a database client" do
           expect(subject).to be_a(Scalingo::Database)
           expect(subject).to be_authenticated
-          expect(subject.token.value).to eq "some-token"
+          expect(subject.token.value).to eq(jwt)
         end
       end
 

--- a/spec/scalingo/regional/addons_spec.rb
+++ b/spec/scalingo/regional/addons_spec.rb
@@ -110,7 +110,9 @@ RSpec.describe Scalingo::Regional::Addons, type: :endpoint do
           stub_request(:post, "http://localhost/apps/my-app-id/addons/addon-id/token").to_return(status: 404)
         end
 
-        it { is_expected.to be_nil }
+        it "raises an exception" do
+          expect { subject }.to raise_error(Faraday::ResourceNotFound)
+        end
       end
     end
   end

--- a/spec/scalingo/regional/logs_spec.rb
+++ b/spec/scalingo/regional/logs_spec.rb
@@ -55,16 +55,11 @@ RSpec.describe Scalingo::Regional::Logs, type: :endpoint do
 
     context "with a failed call for the logs url" do
       before do
-        stub_request(:get, api_path.merge("/apps/my-app-id/logs")).to_return(
-          status: 404,
-          body: "http://localhost/signed-url"
-        )
+        stub_request(:get, api_path.merge("/apps/my-app-id/logs")).to_return(status: 404)
       end
 
-      it "returns the first response" do
-        expect(subject).not_to have_requested(:get, "http://localhost/signed-url")
-        expect(subject.status).to eq 404
-        expect(subject.env.url).to eq api_path.merge("/apps/my-app-id/logs")
+      it "raises an exception" do
+        expect { subject }.to raise_error(Faraday::ResourceNotFound)
       end
     end
   end

--- a/spec/scalingo/token_holder_spec.rb
+++ b/spec/scalingo/token_holder_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Scalingo::TokenHolder do
     }
   end
 
-  describe "authenticate_with_bearer_token" do
-    subject { token_holder.authenticate_with_bearer_token(token, expires_at: expires_at, raise_on_expired_token: false) }
+  describe "#token=" do
+    subject { token_holder.token = token }
 
     let(:token_holder) do
       holder = token_holder_dummy_class.new
@@ -19,8 +19,7 @@ RSpec.describe Scalingo::TokenHolder do
     end
 
     context "without expiration date" do
-      let(:token) { "1234" }
-      let(:expires_at) { nil }
+      let(:token) { Scalingo.generate_test_jwt }
 
       it "set the auth token" do
         expect(token_holder.authenticated?).to be false
@@ -30,15 +29,15 @@ RSpec.describe Scalingo::TokenHolder do
     end
 
     context "with an expiration date" do
-      let(:token) { "1234" }
-      let(:expires_at) { Time.now + 1.hour }
+      let(:token) { Scalingo.generate_test_jwt(duration: 1.hour) }
 
       it "refresh the auth token" do
-        token_holder.authenticate_with_bearer_token(token, expires_at: 1.hour.ago, raise_on_expired_token: false)
-        expect(token_holder.authenticated?).to be false
-
-        subject
+        token_holder.token = token
         expect(token_holder.authenticated?).to be true
+
+        travel_to(Time.current + 2.hours) do
+          expect(token_holder.authenticated?).to be false
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "bundler/setup"
 require "active_support/all"
+require "active_support/testing/time_helpers"
 
 if ENV["COVERAGE"]
   require "simplecov"
@@ -29,6 +30,7 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
+  config.include ActiveSupport::Testing::TimeHelpers
   config.include_context "with the default endpoint context", type: :endpoint
 
   config.before(:each, type: :endpoint) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require "bundler/setup"
 require "active_support/all"
 require "active_support/testing/time_helpers"
+require "ostruct"
 
 if ENV["COVERAGE"]
   require "simplecov"

--- a/spec/support/scalingo.rb
+++ b/spec/support/scalingo.rb
@@ -1,0 +1,10 @@
+module Scalingo
+  def generate_test_jwt(duration: nil)
+    payload = {iss: "Scalingo Test"}
+    payload[:exp] = Time.now.to_i + duration.to_i if duration.present?
+
+    JWT.encode payload, nil, "none"
+  end
+
+  module_function :generate_test_jwt
+end

--- a/spec/support/shared.rb
+++ b/spec/support/shared.rb
@@ -4,7 +4,7 @@ RSpec.shared_context "with the default endpoint context" do
     WebMock # returning this lets us use the one-liner `have_requested` syntax
   end
 
-  let(:bearer_token) { "Bearer token" }
+  let(:bearer_token) { Scalingo.generate_test_jwt(duration: 1.hour) }
 
   let(:arguments) do
     args = {}


### PR DESCRIPTION
This PR re-orients the gem towards raising exception when something goes wrong (while previously it was configurable).

This means raising exceptions on error responses, but also when the token is missing and when it is expired.

The code is smaller/simpler as a result, which is always nice.

Side tasks:
- token expiration is read directly from the token instead of assuming 1h (and leaving room to customize it). this adds a dependency on `jwt`
- `addressable` was missing in the dependencies of the gem (it was introduced a couple of PRs ago)
- some dead code/comments were still around
- changelog/readme was updated

This also marks the gem as 4.0 beta 1, as the largest internal work is now complete