### PR TITLE
[STORY-2340] Add method to update collaborators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ coverage/
 /pkg
 
 .rspec_status
+
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## To be released
+
+* New: add collaborator update method
+
 ## 4.0.beta1 - 2024-04-15
 
 * Breaking change: exceptions are raised on error responses (4xx, 5xx) and other errors (connection issue, timeouts)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## To be released
 
+## 4.0.0 - 2025-07-29
+
 * New: add collaborator update method
 
 ## 4.0.beta1 - 2024-04-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## To be released
 
-## 4.0.0 - 2025-07-29
+## 4.0.beta3 - 2025-07-29
 
 * New: add collaborator update method
 

--- a/lib/scalingo/regional/collaborators.rb
+++ b/lib/scalingo/regional/collaborators.rb
@@ -6,5 +6,6 @@ module Scalingo
     post :create, "apps/{app_id}/collaborators", root_key: "collaborator"
     delete :delete, "apps/{app_id}/collaborators/{id}"
     get :accept, "apps/collaboration?token={token}"
+    patch :update, "apps/{app_id}/collaborators/{id}", root_key: "collaborator"
   end
 end

--- a/spec/scalingo/auth/keys_spec.rb
+++ b/spec/scalingo/auth/keys_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Scalingo::Auth::Keys, type: :endpoint do
   describe "list" do
     subject(:response) { instance.list(**arguments) }
 
-    include_examples "requires authentication"
+    it_behaves_like "requires authentication"
 
     it { is_expected.to have_requested(:get, api_path.merge("/keys")) }
   end
@@ -14,7 +14,7 @@ RSpec.describe Scalingo::Auth::Keys, type: :endpoint do
 
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
+    it_behaves_like "requires authentication"
 
     it { is_expected.to have_requested(:post, api_path.merge("/keys")).with(body: {key: body}) }
   end
@@ -24,8 +24,8 @@ RSpec.describe Scalingo::Auth::Keys, type: :endpoint do
 
     let(:params) { {id: "key-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :id
 
     it { is_expected.to have_requested(:get, api_path.merge("/keys/key-id")) }
   end
@@ -35,8 +35,8 @@ RSpec.describe Scalingo::Auth::Keys, type: :endpoint do
 
     let(:params) { {id: "key-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :id
 
     it { is_expected.to have_requested(:delete, api_path.merge("/keys/key-id")) }
   end

--- a/spec/scalingo/auth/scm_integrations_spec.rb
+++ b/spec/scalingo/auth/scm_integrations_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Scalingo::Auth::ScmIntegrations, type: :endpoint do
   describe "list" do
     subject(:response) { instance.list(**arguments) }
 
-    include_examples "requires authentication"
+    it_behaves_like "requires authentication"
 
     it { is_expected.to have_requested(:get, api_path.merge("/scm_integrations")) }
   end
@@ -14,7 +14,7 @@ RSpec.describe Scalingo::Auth::ScmIntegrations, type: :endpoint do
 
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
+    it_behaves_like "requires authentication"
 
     it { is_expected.to have_requested(:post, api_path.merge("/scm_integrations")).with(body: {scm_integration: body}) }
   end
@@ -24,8 +24,8 @@ RSpec.describe Scalingo::Auth::ScmIntegrations, type: :endpoint do
 
     let(:params) { {id: "scm-integration-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :id
 
     it { is_expected.to have_requested(:get, api_path.merge("/scm_integrations/scm-integration-id")) }
   end
@@ -35,8 +35,8 @@ RSpec.describe Scalingo::Auth::ScmIntegrations, type: :endpoint do
 
     let(:params) { {id: "scm-integration-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :id
 
     it { is_expected.to have_requested(:delete, api_path.merge("/scm_integrations/scm-integration-id")) }
   end

--- a/spec/scalingo/auth/tokens_spec.rb
+++ b/spec/scalingo/auth/tokens_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Scalingo::Auth::Tokens, type: :endpoint do
   describe "list" do
     subject(:response) { instance.list(**arguments) }
 
-    include_examples "requires authentication"
+    it_behaves_like "requires authentication"
 
     it { is_expected.to have_requested(:get, api_path.merge("/tokens")) }
   end
@@ -14,7 +14,7 @@ RSpec.describe Scalingo::Auth::Tokens, type: :endpoint do
 
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
+    it_behaves_like "requires authentication"
 
     it { is_expected.to have_requested(:post, api_path.merge("/tokens")).with(body: {token: body}) }
   end
@@ -35,8 +35,8 @@ RSpec.describe Scalingo::Auth::Tokens, type: :endpoint do
 
     let(:params) { {id: "token-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :id
 
     it { is_expected.to have_requested(:put, api_path.merge("/tokens/token-id/renew")) }
   end
@@ -46,8 +46,8 @@ RSpec.describe Scalingo::Auth::Tokens, type: :endpoint do
 
     let(:params) { {id: "token-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :id
 
     it { is_expected.to have_requested(:delete, api_path.merge("/tokens/token-id")) }
   end

--- a/spec/scalingo/auth/two_factor_auth_spec.rb
+++ b/spec/scalingo/auth/two_factor_auth_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Scalingo::Auth::TwoFactorAuth, type: :endpoint do
   describe "status" do
     subject(:response) { instance.status(**arguments) }
 
-    include_examples "requires authentication"
+    it_behaves_like "requires authentication"
 
     it { is_expected.to have_requested(:get, api_path.merge("/client/tfa")) }
   end
@@ -14,7 +14,7 @@ RSpec.describe Scalingo::Auth::TwoFactorAuth, type: :endpoint do
 
     let(:body) { {provider: "value"} }
 
-    include_examples "requires authentication"
+    it_behaves_like "requires authentication"
 
     it { is_expected.to have_requested(:post, api_path.merge("/client/tfa")).with(body: {tfa: body}) }
   end
@@ -24,7 +24,7 @@ RSpec.describe Scalingo::Auth::TwoFactorAuth, type: :endpoint do
 
     let(:body) { {attempt: "value"} }
 
-    include_examples "requires authentication"
+    it_behaves_like "requires authentication"
 
     it { is_expected.to have_requested(:post, api_path.merge("/client/tfa/validate")).with(body: {tfa: body}) }
   end
@@ -32,7 +32,7 @@ RSpec.describe Scalingo::Auth::TwoFactorAuth, type: :endpoint do
   describe "disable" do
     subject(:response) { instance.disable(**arguments) }
 
-    include_examples "requires authentication"
+    it_behaves_like "requires authentication"
 
     it { is_expected.to have_requested(:delete, api_path.merge("/client/tfa")) }
   end

--- a/spec/scalingo/auth/user_spec.rb
+++ b/spec/scalingo/auth/user_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Scalingo::Auth::User, type: :endpoint do
   describe "find" do
     subject(:response) { instance.find(**arguments) }
 
-    include_examples "requires authentication"
+    it_behaves_like "requires authentication"
 
     it { is_expected.to have_requested(:get, api_path.merge("/users/self")) }
   end
@@ -14,7 +14,7 @@ RSpec.describe Scalingo::Auth::User, type: :endpoint do
 
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
+    it_behaves_like "requires authentication"
 
     it { is_expected.to have_requested(:put, api_path.merge("/users/account")).with(body: {user: body}) }
   end
@@ -22,7 +22,7 @@ RSpec.describe Scalingo::Auth::User, type: :endpoint do
   describe "stop free trial" do
     subject(:response) { instance.stop_free_trial(**arguments) }
 
-    include_examples "requires authentication"
+    it_behaves_like "requires authentication"
 
     it { is_expected.to have_requested(:post, api_path.merge("/users/stop_free_trial")) }
   end

--- a/spec/scalingo/billing/profile_spec.rb
+++ b/spec/scalingo/billing/profile_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Scalingo::Billing::Profile, type: :endpoint do
 
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
+    it_behaves_like "requires authentication"
 
     it { is_expected.to have_requested(:post, api_path.merge("/profiles")).with(body: {profile: body}) }
   end
@@ -14,7 +14,7 @@ RSpec.describe Scalingo::Billing::Profile, type: :endpoint do
   describe "find" do
     subject(:response) { instance.find(**arguments) }
 
-    include_examples "requires authentication"
+    it_behaves_like "requires authentication"
 
     it { is_expected.to have_requested(:get, api_path.merge("/profile")) }
   end
@@ -25,8 +25,8 @@ RSpec.describe Scalingo::Billing::Profile, type: :endpoint do
     let(:params) { {id: "profile-id"} }
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :id
 
     it { is_expected.to have_requested(:put, api_path.merge("/profiles/profile-id")).with(body: {profile: body}) }
   end

--- a/spec/scalingo/database/backups_spec.rb
+++ b/spec/scalingo/database/backups_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Scalingo::Database::Backups, type: :endpoint do
 
     let(:params) { {addon_id: addon_id} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :addon_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :addon_id
 
     it { is_expected.to have_requested(:get, api_path.merge("/databases/the-addon-id/backups")) }
   end
@@ -20,8 +20,8 @@ RSpec.describe Scalingo::Database::Backups, type: :endpoint do
     let(:params) { {addon_id: addon_id} }
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :addon_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :addon_id
 
     it { is_expected.to have_requested(:post, api_path.merge("/databases/the-addon-id/backups")) }
   end
@@ -31,8 +31,8 @@ RSpec.describe Scalingo::Database::Backups, type: :endpoint do
 
     let(:params) { {addon_id: addon_id, id: "backup-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :addon_id, :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :addon_id, :id
 
     it { is_expected.to have_requested(:get, api_path.merge("/databases/the-addon-id/backups/backup-id/archive")) }
   end

--- a/spec/scalingo/database/databases_spec.rb
+++ b/spec/scalingo/database/databases_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Scalingo::Database::Databases, type: :endpoint do
 
     let(:params) { {id: id} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :id
 
     it { is_expected.to have_requested(:get, api_path.merge("/databases/database-id")) }
   end
@@ -19,8 +19,8 @@ RSpec.describe Scalingo::Database::Databases, type: :endpoint do
 
     let(:params) { {id: id} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :id
 
     it { is_expected.to have_requested(:post, api_path.merge("/databases/database-id/upgrade")) }
   end

--- a/spec/scalingo/faraday/extract_meta_spec.rb
+++ b/spec/scalingo/faraday/extract_meta_spec.rb
@@ -33,30 +33,30 @@ RSpec.describe Scalingo::ExtractMeta do
     let(:content_type) { "text/html" }
     let(:body) { "string".to_json }
 
-    include_examples "no meta extraction"
+    it_behaves_like "no meta extraction"
   end
 
   context "without a body" do
-    include_examples "no meta extraction"
+    it_behaves_like "no meta extraction"
   end
 
   context "with a non indexable body" do
     let(:body) { "string".to_json }
 
-    include_examples "no meta extraction"
+    it_behaves_like "no meta extraction"
   end
 
   context "with a non hash indexable body" do
     let(:body) { [1, 2, 3].to_json }
 
-    include_examples "no meta extraction"
+    it_behaves_like "no meta extraction"
   end
 
   context "with a hash" do
     context "without a meta key" do
       let(:body) { {a: 1, b: 2}.to_json }
 
-      include_examples "no meta extraction"
+      it_behaves_like "no meta extraction"
     end
 
     context "with a generic meta key" do

--- a/spec/scalingo/regional/addons_spec.rb
+++ b/spec/scalingo/regional/addons_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe Scalingo::Regional::Addons, type: :endpoint do
 
     let(:params) { {app_id: app_id} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/addons")) }
   end
@@ -32,8 +32,8 @@ RSpec.describe Scalingo::Regional::Addons, type: :endpoint do
     let(:params) { {app_id: app_id} }
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:post, api_path.merge("/apps/my-app-id/addons")).with(body: {addon: body}) }
   end
@@ -43,8 +43,8 @@ RSpec.describe Scalingo::Regional::Addons, type: :endpoint do
 
     let(:params) { {app_id: app_id, id: "addon-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id, :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id, :id
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/addons/addon-id")) }
   end
@@ -55,8 +55,8 @@ RSpec.describe Scalingo::Regional::Addons, type: :endpoint do
     let(:params) { {app_id: app_id, id: "addon-id"} }
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id, :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id, :id
 
     it { is_expected.to have_requested(:put, api_path.merge("/apps/my-app-id/addons/addon-id")).with(body: {addon: body}) }
   end
@@ -66,8 +66,8 @@ RSpec.describe Scalingo::Regional::Addons, type: :endpoint do
 
     let(:params) { {app_id: app_id, id: "addon-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id, :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id, :id
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/addons/addon-id/sso")) }
   end
@@ -77,8 +77,8 @@ RSpec.describe Scalingo::Regional::Addons, type: :endpoint do
 
     let(:params) { {app_id: app_id, id: "addon-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id, :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id, :id
 
     it { is_expected.to have_requested(:post, api_path.merge("/apps/my-app-id/addons/addon-id/token")) }
 
@@ -124,8 +124,8 @@ RSpec.describe Scalingo::Regional::Addons, type: :endpoint do
 
     let(:params) { {app_id: app_id, id: "addon-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id, :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id, :id
 
     it { is_expected.to have_requested(:delete, api_path.merge("/apps/my-app-id/addons/addon-id")) }
   end

--- a/spec/scalingo/regional/apps_spec.rb
+++ b/spec/scalingo/regional/apps_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Scalingo::Regional::Apps, type: :endpoint do
   describe "list" do
     subject(:response) { instance.list(**arguments) }
 
-    include_examples "requires authentication"
+    it_behaves_like "requires authentication"
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps")) }
   end
@@ -14,7 +14,7 @@ RSpec.describe Scalingo::Regional::Apps, type: :endpoint do
 
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
+    it_behaves_like "requires authentication"
 
     it { is_expected.to have_requested(:post, api_path.merge("/apps")).with(body: {app: body}) }
 
@@ -30,8 +30,8 @@ RSpec.describe Scalingo::Regional::Apps, type: :endpoint do
 
     let(:params) { {id: "my-app-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :id
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id")) }
   end
@@ -41,8 +41,8 @@ RSpec.describe Scalingo::Regional::Apps, type: :endpoint do
 
     let(:params) { {id: "my-app-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :id
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/logs")) }
   end
@@ -53,8 +53,8 @@ RSpec.describe Scalingo::Regional::Apps, type: :endpoint do
     let(:params) { {id: "my-app-id"} }
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :id
 
     it { is_expected.to have_requested(:put, api_path.merge("/apps/my-app-id")).with(body: {app: body}) }
   end
@@ -65,8 +65,8 @@ RSpec.describe Scalingo::Regional::Apps, type: :endpoint do
     let(:params) { {id: "my-app-id"} }
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :id
 
     it { is_expected.to have_requested(:post, api_path.merge("/apps/my-app-id/rename")).with(body: body) }
   end
@@ -77,8 +77,8 @@ RSpec.describe Scalingo::Regional::Apps, type: :endpoint do
     let(:params) { {id: "my-app-id"} }
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :id
 
     it { is_expected.to have_requested(:put, api_path.merge("/apps/my-app-id")).with(body: body) }
   end
@@ -88,8 +88,8 @@ RSpec.describe Scalingo::Regional::Apps, type: :endpoint do
 
     let(:params) { {id: "my-app-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :id
 
     it { is_expected.to have_requested(:delete, api_path.merge("/apps/my-app-id")) }
   end

--- a/spec/scalingo/regional/autoscalers_spec.rb
+++ b/spec/scalingo/regional/autoscalers_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Scalingo::Regional::Autoscalers, type: :endpoint do
 
     let(:params) { {app_id: app_id} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/autoscalers")) }
   end
@@ -20,8 +20,8 @@ RSpec.describe Scalingo::Regional::Autoscalers, type: :endpoint do
     let(:params) { {app_id: app_id} }
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:post, api_path.merge("/apps/my-app-id/autoscalers")).with(body: {autoscaler: body}) }
   end
@@ -31,8 +31,8 @@ RSpec.describe Scalingo::Regional::Autoscalers, type: :endpoint do
 
     let(:params) { {app_id: app_id, id: "autoscaler-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id, :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id, :id
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/autoscalers/autoscaler-id")) }
   end
@@ -43,8 +43,8 @@ RSpec.describe Scalingo::Regional::Autoscalers, type: :endpoint do
     let(:params) { {app_id: app_id, id: "autoscaler-id"} }
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id, :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id, :id
 
     it { is_expected.to have_requested(:put, api_path.merge("/apps/my-app-id/autoscalers/autoscaler-id")).with(body: {autoscaler: body}) }
   end
@@ -54,8 +54,8 @@ RSpec.describe Scalingo::Regional::Autoscalers, type: :endpoint do
 
     let(:params) { {app_id: app_id, id: "autoscaler-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id, :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id, :id
 
     it { is_expected.to have_requested(:delete, api_path.merge("/apps/my-app-id/autoscalers/autoscaler-id")) }
   end

--- a/spec/scalingo/regional/collaborators_spec.rb
+++ b/spec/scalingo/regional/collaborators_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Scalingo::Regional::Collaborators, type: :endpoint do
 
     let(:params) { {app_id: app_id} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/collaborators")) }
   end
@@ -19,8 +19,8 @@ RSpec.describe Scalingo::Regional::Collaborators, type: :endpoint do
 
     let(:params) { {app_id: app_id, token: "some-token"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :token
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :token
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps/collaboration?token=some-token")) }
   end
@@ -31,8 +31,8 @@ RSpec.describe Scalingo::Regional::Collaborators, type: :endpoint do
     let(:params) { {app_id: app_id} }
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:post, api_path.merge("/apps/my-app-id/collaborators")).with(body: {collaborator: body}) }
   end
@@ -42,8 +42,8 @@ RSpec.describe Scalingo::Regional::Collaborators, type: :endpoint do
 
     let(:params) { {app_id: app_id, id: "collaborator-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id, :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id, :id
 
     it { is_expected.to have_requested(:delete, api_path.merge("/apps/my-app-id/collaborators/collaborator-id")) }
   end
@@ -53,8 +53,8 @@ RSpec.describe Scalingo::Regional::Collaborators, type: :endpoint do
 
     let(:params) { {app_id: app_id, id: "collaborator-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id, :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id, :id
 
     it { is_expected.to have_requested(:patch, api_path.merge("/apps/my-app-id/collaborators/collaborator-id")) }
   end

--- a/spec/scalingo/regional/collaborators_spec.rb
+++ b/spec/scalingo/regional/collaborators_spec.rb
@@ -47,4 +47,15 @@ RSpec.describe Scalingo::Regional::Collaborators, type: :endpoint do
 
     it { is_expected.to have_requested(:delete, api_path.merge("/apps/my-app-id/collaborators/collaborator-id")) }
   end
+
+  describe "update" do
+    subject(:response) { instance.update(**arguments) }
+
+    let(:params) { {app_id: app_id, id: "collaborator-id"} }
+
+    include_examples "requires authentication"
+    include_examples "requires some params", :app_id, :id
+
+    it { is_expected.to have_requested(:patch, api_path.merge("/apps/my-app-id/collaborators/collaborator-id")) }
+  end
 end

--- a/spec/scalingo/regional/collaborators_spec.rb
+++ b/spec/scalingo/regional/collaborators_spec.rb
@@ -52,10 +52,11 @@ RSpec.describe Scalingo::Regional::Collaborators, type: :endpoint do
     subject(:response) { instance.update(**arguments) }
 
     let(:params) { {app_id: app_id, id: "collaborator-id"} }
+    let(:body) { {field: "value"} }
 
     it_behaves_like "requires authentication"
     it_behaves_like "requires some params", :app_id, :id
 
-    it { is_expected.to have_requested(:patch, api_path.merge("/apps/my-app-id/collaborators/collaborator-id")) }
+    it { is_expected.to have_requested(:patch, api_path.merge("/apps/my-app-id/collaborators/collaborator-id")).with(body: {collaborator: body}) }
   end
 end

--- a/spec/scalingo/regional/containers_spec.rb
+++ b/spec/scalingo/regional/containers_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Scalingo::Regional::Containers, type: :endpoint do
 
     let(:params) { {app_id: app_id} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/containers")) }
   end
@@ -26,8 +26,8 @@ RSpec.describe Scalingo::Regional::Containers, type: :endpoint do
     let(:params) { {app_id: app_id} }
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:post, api_path.merge("/apps/my-app-id/scale")).with(body: {containers: body}) }
   end
@@ -38,8 +38,8 @@ RSpec.describe Scalingo::Regional::Containers, type: :endpoint do
     let(:params) { {app_id: app_id} }
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:post, api_path.merge("/apps/my-app-id/restart")).with(body: {scope: body}) }
   end

--- a/spec/scalingo/regional/deployments_spec.rb
+++ b/spec/scalingo/regional/deployments_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Scalingo::Regional::Deployments, type: :endpoint do
 
     let(:params) { {app_id: app_id} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/deployments")) }
 
@@ -25,8 +25,8 @@ RSpec.describe Scalingo::Regional::Deployments, type: :endpoint do
 
     let(:params) { {app_id: app_id, id: "deployment-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id, :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id, :id
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/deployments/deployment-id")) }
   end
@@ -36,8 +36,8 @@ RSpec.describe Scalingo::Regional::Deployments, type: :endpoint do
 
     let(:params) { {app_id: app_id, id: "deployment-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id, :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id, :id
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/deployments/deployment-id/output")) }
   end

--- a/spec/scalingo/regional/domains_spec.rb
+++ b/spec/scalingo/regional/domains_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Scalingo::Regional::Domains, type: :endpoint do
 
     let(:params) { {app_id: app_id} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/domains")) }
   end
@@ -20,8 +20,8 @@ RSpec.describe Scalingo::Regional::Domains, type: :endpoint do
     let(:params) { {app_id: app_id} }
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:post, api_path.merge("/apps/my-app-id/domains")).with(body: {domain: body}) }
   end
@@ -31,8 +31,8 @@ RSpec.describe Scalingo::Regional::Domains, type: :endpoint do
 
     let(:params) { {app_id: app_id, id: "domain-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id, :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id, :id
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/domains/domain-id")) }
   end
@@ -43,8 +43,8 @@ RSpec.describe Scalingo::Regional::Domains, type: :endpoint do
     let(:params) { {app_id: app_id, id: "domain-id"} }
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id, :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id, :id
 
     it { is_expected.to have_requested(:put, api_path.merge("/apps/my-app-id/domains/domain-id")).with(body: {domain: body}) }
   end
@@ -54,8 +54,8 @@ RSpec.describe Scalingo::Regional::Domains, type: :endpoint do
 
     let(:params) { {app_id: app_id, id: "domain-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id, :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id, :id
 
     it { is_expected.to have_requested(:delete, api_path.merge("/apps/my-app-id/domains/domain-id")) }
   end

--- a/spec/scalingo/regional/environment_spec.rb
+++ b/spec/scalingo/regional/environment_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Scalingo::Regional::Environment, type: :endpoint do
 
     let(:params) { {app_id: app_id} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/variables")) }
   end
@@ -20,8 +20,8 @@ RSpec.describe Scalingo::Regional::Environment, type: :endpoint do
     let(:params) { {app_id: app_id} }
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:post, api_path.merge("/apps/my-app-id/variables")).with(body: {variable: body}) }
   end
@@ -32,8 +32,8 @@ RSpec.describe Scalingo::Regional::Environment, type: :endpoint do
     let(:params) { {app_id: app_id, id: "variable-id"} }
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id, :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id, :id
 
     it { is_expected.to have_requested(:put, api_path.merge("/apps/my-app-id/variables/variable-id")).with(body: {variable: body}) }
   end
@@ -44,8 +44,8 @@ RSpec.describe Scalingo::Regional::Environment, type: :endpoint do
     let(:params) { {app_id: app_id} }
     let(:body) { [{field: "value"}] }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:put, api_path.merge("/apps/my-app-id/variables")).with(body: {variables: body}) }
   end
@@ -55,8 +55,8 @@ RSpec.describe Scalingo::Regional::Environment, type: :endpoint do
 
     let(:params) { {app_id: app_id, id: "variable-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id, :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id, :id
 
     it { is_expected.to have_requested(:delete, api_path.merge("/apps/my-app-id/variables/variable-id")) }
   end
@@ -67,8 +67,8 @@ RSpec.describe Scalingo::Regional::Environment, type: :endpoint do
     let(:params) { {app_id: app_id} }
     let(:body) { [1, 2, 3] }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:delete, api_path.merge("/apps/my-app-id/variables")).with(body: {variable_ids: body}) }
   end

--- a/spec/scalingo/regional/events_spec.rb
+++ b/spec/scalingo/regional/events_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Scalingo::Regional::Events, type: :endpoint do
   describe "list" do
     subject(:response) { instance.list(**arguments) }
 
-    include_examples "requires authentication"
+    it_behaves_like "requires authentication"
 
     it { is_expected.to have_requested(:get, api_path.merge("/events")) }
 

--- a/spec/scalingo/regional/logs_spec.rb
+++ b/spec/scalingo/regional/logs_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Scalingo::Regional::Logs, type: :endpoint do
 
     let(:params) { {app_id: app_id} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/logs_archives")) }
   end
@@ -17,7 +17,7 @@ RSpec.describe Scalingo::Regional::Logs, type: :endpoint do
   describe "fetch" do
     subject(:response) { instance.fetch("http://localhost/any-url", **arguments) }
 
-    include_examples "requires authentication"
+    it_behaves_like "requires authentication"
 
     it { is_expected.to have_requested(:get, "http://localhost/any-url") }
 
@@ -39,8 +39,8 @@ RSpec.describe Scalingo::Regional::Logs, type: :endpoint do
 
     let(:params) { {app_id: app_id} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     context "with a successful call for the logs url" do
       before do

--- a/spec/scalingo/regional/metrics_spec.rb
+++ b/spec/scalingo/regional/metrics_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Scalingo::Regional::Metrics, type: :endpoint do
 
     let(:params) { {app_id: app_id, metric: "some-metric"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id, :metric
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id, :metric
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/stats/some-metric")) }
 

--- a/spec/scalingo/regional/notifiers_spec.rb
+++ b/spec/scalingo/regional/notifiers_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Scalingo::Regional::Notifiers, type: :endpoint do
 
     let(:params) { {app_id: app_id} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/notifiers")) }
   end
@@ -26,8 +26,8 @@ RSpec.describe Scalingo::Regional::Notifiers, type: :endpoint do
     let(:params) { {app_id: app_id} }
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:post, api_path.merge("/apps/my-app-id/notifiers")).with(body: {notifier: body}) }
   end
@@ -37,8 +37,8 @@ RSpec.describe Scalingo::Regional::Notifiers, type: :endpoint do
 
     let(:params) { {app_id: app_id, id: "notifier-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id, :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id, :id
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/notifiers/notifier-id")) }
   end
@@ -49,8 +49,8 @@ RSpec.describe Scalingo::Regional::Notifiers, type: :endpoint do
     let(:params) { {app_id: app_id, id: "notifier-id"} }
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id, :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id, :id
 
     it { is_expected.to have_requested(:put, api_path.merge("/apps/my-app-id/notifiers/notifier-id")).with(body: {notifier: body}) }
   end
@@ -60,8 +60,8 @@ RSpec.describe Scalingo::Regional::Notifiers, type: :endpoint do
 
     let(:params) { {app_id: app_id, id: "notifier-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id, :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id, :id
 
     it { is_expected.to have_requested(:post, api_path.merge("/apps/my-app-id/notifiers/notifier-id/test")) }
   end
@@ -71,8 +71,8 @@ RSpec.describe Scalingo::Regional::Notifiers, type: :endpoint do
 
     let(:params) { {app_id: app_id, id: "notifier-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id, :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id, :id
 
     it { is_expected.to have_requested(:delete, api_path.merge("/apps/my-app-id/notifiers/notifier-id")) }
   end

--- a/spec/scalingo/regional/operations_spec.rb
+++ b/spec/scalingo/regional/operations_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Scalingo::Regional::Operations, type: :endpoint do
 
     let(:params) { {app_id: app_id, id: "op-id"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id, :id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id, :id
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/operations/op-id")) }
   end
@@ -17,7 +17,7 @@ RSpec.describe Scalingo::Regional::Operations, type: :endpoint do
   describe "fetch" do
     subject(:response) { instance.fetch("http://localhost/any-url") }
 
-    include_examples "requires authentication"
+    it_behaves_like "requires authentication"
 
     it { is_expected.to have_requested(:get, "http://localhost/any-url") }
   end

--- a/spec/scalingo/regional/scm_repo_links_spec.rb
+++ b/spec/scalingo/regional/scm_repo_links_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Scalingo::Regional::ScmRepoLinks, type: :endpoint do
 
     let(:params) { {app_id: app_id} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/scm_repo_link")) }
   end
@@ -19,8 +19,8 @@ RSpec.describe Scalingo::Regional::ScmRepoLinks, type: :endpoint do
 
     let(:params) { {app_id: app_id} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/scm_repo_link/branches")) }
   end
@@ -30,8 +30,8 @@ RSpec.describe Scalingo::Regional::ScmRepoLinks, type: :endpoint do
 
     let(:params) { {app_id: app_id} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:get, api_path.merge("/apps/my-app-id/scm_repo_link/pulls")) }
   end
@@ -42,8 +42,8 @@ RSpec.describe Scalingo::Regional::ScmRepoLinks, type: :endpoint do
     let(:params) { {app_id: app_id} }
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:post, api_path.merge("/apps/my-app-id/scm_repo_link")).with(body: {scm_repo_link: body}) }
   end
@@ -54,8 +54,8 @@ RSpec.describe Scalingo::Regional::ScmRepoLinks, type: :endpoint do
     let(:params) { {app_id: app_id} }
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:post, api_path.merge("/apps/my-app-id/scm_repo_link/manual_deploy")).with(body: body) }
   end
@@ -66,8 +66,8 @@ RSpec.describe Scalingo::Regional::ScmRepoLinks, type: :endpoint do
     let(:params) { {app_id: app_id} }
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:post, api_path.merge("/apps/my-app-id/scm_repo_link/manual_review_app")).with(body: body) }
   end
@@ -78,8 +78,8 @@ RSpec.describe Scalingo::Regional::ScmRepoLinks, type: :endpoint do
     let(:params) { {app_id: app_id} }
     let(:body) { {field: "value"} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:put, api_path.merge("/apps/my-app-id/scm_repo_link")).with(body: {scm_repo_link: body}) }
   end
@@ -89,8 +89,8 @@ RSpec.describe Scalingo::Regional::ScmRepoLinks, type: :endpoint do
 
     let(:params) { {app_id: app_id} }
 
-    include_examples "requires authentication"
-    include_examples "requires some params", :app_id
+    it_behaves_like "requires authentication"
+    it_behaves_like "requires some params", :app_id
 
     it { is_expected.to have_requested(:delete, api_path.merge("/apps/my-app-id/scm_repo_link")) }
   end


### PR DESCRIPTION
The Ruby SDK wasn't updated to include the method to update a collaborator. The main changes are in:

- `collaborators.rb`
- `collaborators_spec.rb`

The rest of the spec update is a Rubocop requirement to pass the CI.