### PR TITLE
chore(deps): remove unused multi_json dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## To be released
 
+* Change: remove the unused `multi_json` runtime dependency. JSON is handled by Faraday's `:json` middleware (stdlib `JSON`), so the gem never called `MultiJson`.
+
 ## 4.0.beta4 - 2026-02-26
 
 * Added support for Ruby on Rails 8.x ([PR#73](https://github.com/Scalingo/scalingo-ruby-api/pull/73) by [@zaratan](https://github.com/zaratan))

--- a/scalingo.gemspec
+++ b/scalingo.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |s|
   s.add_dependency "addressable", [">= 2.8.0", "< 3"]
   s.add_dependency "activesupport", [">= 5", "< 9"]
   s.add_dependency "faraday", "~> 2.0"
-  s.add_dependency "multi_json", ">= 1.0.3", "~> 1.0"
   s.add_dependency "jwt"
 
   s.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
## What

This removes the `multi_json` runtime dependency from the gemspec. It was declared but the gem never actually used it.

## Why

I ran into this deprecation warning while using the gem:

> MultiJSON.load is deprecated and will be removed in v2.0. Use MultiJSON.parse instead.

When I went looking for the `MultiJson.load` call to fix, there wasn't one. `multi_json` is listed as a runtime dependency in `scalingo.gemspec`, but nothing in the codebase calls it:

- JSON requests and responses go through Faraday's built-in `:json` middleware (`lib/scalingo/api/client.rb`), which uses stdlib `JSON` on Faraday 2.
- JWT decoding uses `JWT.decode` (`lib/scalingo/bearer_token.rb`).
- `grep -rni multi_json` only matches the gemspec line. There's no `require "multi_json"` and no `MultiJson` call anywhere, in the current code or the git history.

So the dependency is dead weight. Dropping it keeps it out of consumers' bundles and stops its deprecation warnings from leaking into apps that depend on this gem.

## Testing

- `gem build scalingo.gemspec` succeeds.
- Full spec suite passes: `371 examples, 0 failures`.
